### PR TITLE
Copy types from log into dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "tsc": "tsc -p .",
     "tsc-watch": "tsc -p . --watch",
-    "rollup": "rollup -c && cp lib/generator.d.ts dist/generator.d.ts",
+    "rollup": "rollup -c && cp lib/generator.d.ts dist/generator.d.ts && mkdir -p dist/common && cp lib/common/log.d.ts dist/common/log.d.ts",
     "build": "npm run tsc && npm run rollup",
     "test": "node test/test.js"
   },


### PR DESCRIPTION
Encountered a small problem with types when trying generator in typescript project.  Types from `log` are missing in `dist` that's in `npm`
https://unpkg.com/browse/@jspm/generator@1.0.0-beta.2/dist/generator.d.ts