### PR TITLE
Support nodemodules provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
   "devDependencies": {
     "chalk": "^4.1.1",
     "cross-env": "^7.0.2",
+    "lit-element": "^2.5.1",
     "rollup": "^2.44.0",
     "typescript": "^4.1.3"
   },

--- a/src/common/fetch-node.ts
+++ b/src/common/fetch-node.ts
@@ -57,9 +57,20 @@ export const fetch = async function (url: URL, ...args: any[]) {
       };
     }
     catch (e) {
-      if (e.code === 'EISDIR' || e.code === 'ENOTDIR')
-        return { status: 404, statusText: e.toString() };
-      if (e.code === 'ENOENT')
+      if (e.code === 'EISDIR')
+        return {
+          status: 200,
+          async text () {
+            return '';
+          },
+          async json () {
+            throw new Error('Not JSON');
+          },
+          arrayBuffer () {
+            return new ArrayBuffer(0);
+          }
+        };
+      if (e.code === 'ENOENT' || e.code === 'ENOENT')
         return { status: 404, statusText: e.toString() };
       return { status: 500, statusText: e.toString() };
     }

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -363,11 +363,11 @@ export class Installer {
     let bestMatch: ExactPackage | null = null;
     for (const pkgUrl of Object.keys(this.installs)) {
       const pkg = this.resolver.parseUrlPkg(pkgUrl);
-      if (pkg && this.inRange(pkg, matchPkg)) {
+      if (pkg && this.inRange(pkg.pkg, matchPkg)) {
         if (bestMatch)
-          bestMatch = Semver.compare(new Semver(bestMatch.version), pkg.version) === -1 ? pkg : bestMatch;
+          bestMatch = Semver.compare(new Semver(bestMatch.version), pkg.pkg.version) === -1 ? pkg.pkg : bestMatch;
         else
-          bestMatch = pkg;
+          bestMatch = pkg.pkg;
       }
     }
     return bestMatch;

--- a/src/install/package.ts
+++ b/src/install/package.ts
@@ -84,8 +84,8 @@ export function isPackageTarget (targetStr: string): boolean {
 export function pkgUrlToNiceString (resolver: Resolver, pkgUrl: string) {
   const pkg = resolver.parseUrlPkg(pkgUrl);
   if (pkg) {
-    const subpath = pkgUrl.slice(resolver.pkgToUrl(pkg, this.defaultProvider).length);
-    return pkgToStr(pkg) + subpath;
+    const subpath = pkgUrl.slice(resolver.pkgToUrl(pkg.pkg, this.defaultProvider).length);
+    return pkgToStr(pkg.pkg) + subpath;
   }
   if (pkgUrl.startsWith('file:')) {
     return urlToNiceStr(pkgUrl);

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -2,22 +2,26 @@ import * as jspm from './jspm.js';
 import * as skypack from './skypack.js';
 import * as jsdelivr from './jsdelivr.js';
 import * as unpkg from './unpkg.js';
+import * as nodemodules from './nodemodules.js';
 import { PackageConfig, ExactPackage } from '../install/package.js';
 import { Resolver } from '../install/resolver.js';
 import { PackageTarget } from '../install/package.js';
 
 export interface Provider {
   name: string;
-  layers: Record<string, string>;
-  parseUrlPkg (this: Resolver, url: string): ExactPackage | undefined;
+  parseUrlPkg (this: Resolver, url: string): ExactPackage | { pkg: ExactPackage, layer: string } | undefined;
   pkgToUrl (this: Resolver, pkg: ExactPackage, layer: string): string;
   getPackageConfig? (this: Resolver, pkgUrl: string): Promise<PackageConfig | null | undefined>;
-  resolveLatestTarget (this: Resolver, target: PackageTarget, unstable: boolean, layer: string, parentUrl?: string): Promise<ExactPackage | null>;
+  resolveLatestTarget (this: Resolver, target: PackageTarget, unstable: boolean, layer: string, parentUrl: string): Promise<ExactPackage | null>;
   getFileList? (this: Resolver, pkgUrl: string): Promise<string[]>;
 }
 
-const providers: Record<string, Provider> = {
-  jspm, skypack, jsdelivr, unpkg
+export const providers: Record<string, Provider> = {
+  jsdelivr,
+  jspm,
+  nodemodules,
+  skypack,
+  unpkg
 };
 
 export function getProvider (name: string) {
@@ -25,14 +29,4 @@ export function getProvider (name: string) {
   if (provider)
     return provider;
   throw new Error('No ' + name + ' provider is defined.');
-}
-
-export function getUrlProvider (url: string): { provider: Provider | null, layer: string | null } {
-  for (const provider of Object.values(providers)) {
-    for (const [layer, cdnUrl] of Object.entries(provider.layers)) {
-      if (url.startsWith(cdnUrl))
-        return { provider, layer };
-    }
-  }
-  return { provider: null, layer: null };
 }

--- a/src/providers/jsdelivr.ts
+++ b/src/providers/jsdelivr.ts
@@ -10,12 +10,12 @@ export function pkgToUrl (pkg: ExactPackage) {
   return cdnUrl + pkg.registry + '/' + pkg.name + '@' + pkg.version + '/';
 }
 
-const exactPkgRegEx = /^((?:@[^/\\%@]+\/)?[^./\\%@][^/\\%@]*)@([^\/]+)(\/.*)?$/;
+const exactPkgRegEx = /^([^\/]+)\/((?:@[^/\\%@]+\/)?[^./\\%@][^/\\%@]*)@([^\/]+)(\/.*)?$/;
 export function parseUrlPkg (url: string): ExactPackage | undefined {
   if (!url.startsWith(cdnUrl))
     return;
-  const [,, name, version] = url.slice(cdnUrl.length).match(exactPkgRegEx) || [];
-  return { registry: 'npm', name, version };
+  const [, registry, name, version] = url.slice(cdnUrl.length).match(exactPkgRegEx) || [];
+  return { registry, name, version };
 }
 
 // Use JSPM verion resolver for now

--- a/src/providers/nodemodules.ts
+++ b/src/providers/nodemodules.ts
@@ -1,0 +1,45 @@
+import { PackageTarget } from "../install/package.js";
+import { ExactPackage } from "../install/package.js";
+import { Resolver } from "../install/resolver.js";
+// @ts-ignore
+import { fetch } from '#fetch';
+import { JspmError } from "../common/err.js";
+import { importedFrom } from "../common/url.js";
+
+export const name = 'nodemodules';
+
+export function pkgToUrl (pkg: ExactPackage) {
+  return new URL(pkg.version + pkg.name + '/').href;
+}
+
+export function parseUrlPkg (this: Resolver, url: string): ExactPackage | undefined {
+  const nodeModulesIndex = url.lastIndexOf('/node_modules/');
+  if (nodeModulesIndex === -1)
+    return undefined;
+  const version = url.slice(0, nodeModulesIndex + 14);
+  const pkgParts = url.slice(nodeModulesIndex + 14).split('/');
+  const name = pkgParts[0][0] === '@' ? pkgParts[0] + '/' + pkgParts[1] : pkgParts[0];
+  return { registry: 'node_modules', name, version };
+}
+
+async function dirExists (url: URL, parentUrl?: string) {
+  const res = await fetch(url, this.fetchOpts);
+  switch (res.status) {
+    case 304:
+    case 200:
+      return true;
+    case 404:
+      return false;
+    default:
+      throw new JspmError(`Invalid status code ${res.status} looking up "${url}" - ${res.statusText}${importedFrom(parentUrl)}`);
+  }
+}
+
+export async function resolveLatestTarget (this: Resolver, target: PackageTarget, _unstable: boolean, _layer: string, parentUrl: string): Promise<ExactPackage | null> {
+  let curUrl = new URL(parentUrl);
+  const rootUrl = new URL('/node_modules/', parentUrl).href;
+  do {
+    curUrl = new URL('../../node_modules/', curUrl);
+  } while (!await dirExists.call(this, curUrl) && curUrl.href !== rootUrl)
+  return { registry: 'node_modules', name: target.name, version: curUrl.href };
+}

--- a/src/providers/skypack.ts
+++ b/src/providers/skypack.ts
@@ -10,10 +10,10 @@ export function pkgToUrl (pkg: ExactPackage) {
 }
 
 const exactPkgRegEx = /^((?:@[^/\\%@]+\/)?[^./\\%@][^/\\%@]*)@([^\/]+)(\/.*)?$/;
-export function parseUrlPkg (url: string): ExactPackage | undefined {
+export function parseUrlPkg (url: string) {
   if (!url.startsWith(cdnUrl))
     return;
-  const [,, name, version] = url.slice(cdnUrl.length).match(exactPkgRegEx) || [];
+  const [, name, version] = url.slice(cdnUrl.length).match(exactPkgRegEx) || [];
   return { registry: 'npm', name, version };
 }
 

--- a/src/providers/unpkg.ts
+++ b/src/providers/unpkg.ts
@@ -4,17 +4,15 @@ export const name = 'unpkg';
 
 const cdnUrl = 'https://unpkg.com/';
 
-export const layers = { default: cdnUrl };
-
 export function pkgToUrl (pkg: ExactPackage) {
   return cdnUrl + pkg.name + '@' + pkg.version + '/';
 }
 
 const exactPkgRegEx = /^((?:@[^/\\%@]+\/)?[^./\\%@][^/\\%@]*)@([^\/]+)(\/.*)?$/;
-export function parseUrlPkg (url: string): ExactPackage | undefined {
+export function parseUrlPkg (url: string) {
   if (!url.startsWith(cdnUrl))
     return;
-  const [,, name, version] = url.slice(cdnUrl.length).match(exactPkgRegEx) || [];
+  const [, name, version] = url.slice(cdnUrl.length).match(exactPkgRegEx) || [];
   return { registry: 'npm', name, version };
 }
 

--- a/test/api/localdeps.test.js
+++ b/test/api/localdeps.test.js
@@ -10,4 +10,4 @@ const generator = new Generator({
 await generator.install({ target: './local/pkg', subpath: './withdep' });
 const json = generator.getMap();
 assert.strictEqual(json.imports['localpkg/withdep'], './local/pkg/b.js');
-assert.strictEqual(json.scopes['./'].dep, './local/dep/main.js');
+assert.strictEqual(json.scopes['./local/pkg/'].dep, './local/dep/main.js');

--- a/test/api/localdepsdirect.test.js
+++ b/test/api/localdepsdirect.test.js
@@ -10,4 +10,4 @@ const generator = new Generator({
 await generator.install({ target: './local/pkg', subpath: './withdep2' });
 const json = generator.getMap();
 assert.strictEqual(json.imports['localpkg/withdep2'], './local/pkg/c.js');
-assert.strictEqual(json.scopes['./'].dep2, './local/dep/main.js');
+assert.strictEqual(json.scopes['./local/pkg/'].dep2, './local/dep/main.js');

--- a/test/api/remotedep.test.js
+++ b/test/api/remotedep.test.js
@@ -9,5 +9,6 @@ const generator = new Generator({
 
 await generator.install({ target: './local/pkg', subpath: './remotedep' });
 const json = generator.getMap();
+console.log(json);
 assert.strictEqual(json.imports['localpkg/remotedep'], './local/pkg/d.js');
-assert.strictEqual(json.scopes['./'].react, 'https://ga.jspm.io/npm:react@16.14.0/index.js');
+assert.strictEqual(json.scopes['./local/pkg/'].react, 'https://ga.jspm.io/npm:react@16.14.0/index.js');

--- a/test/providers/jsdelivr.test.js
+++ b/test/providers/jsdelivr.test.js
@@ -9,8 +9,9 @@ const generator = new Generator({
 
 await generator.install('lit@2.0.0-rc.1');
 const json = generator.getMap();
+
 assert.strictEqual(json.imports.lit, 'https://cdn.jsdelivr.net/npm/lit@2.0.0-rc.1/index.js');
-const scope = json.scopes['https://cdn.jsdelivr.net/'];
+const scope = json.scopes['https://cdn.jsdelivr.net/npm/'];
 assert.ok(scope['@lit/reactive-element']);
 assert.ok(scope['lit-element/lit-element.js']);
 assert.ok(scope['lit-html']);

--- a/test/providers/nodemodules.test.js
+++ b/test/providers/nodemodules.test.js
@@ -1,0 +1,16 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+const generator = new Generator({
+  mapUrl: import.meta.url,
+  defaultProvider: 'nodemodules'
+});
+
+await generator.install('lit-element');
+await generator.install('lit-html');
+
+const json = generator.getMap();
+
+assert.strictEqual(json.imports['lit-element'], '../../node_modules/lit-element/lit-element.js');
+assert.strictEqual(json.scopes['../../node_modules/lit-element/']['lit-html/lib/shady-render.js'], '../../node_modules/lit-html/lib/shady-render.js');
+assert.strictEqual(json.scopes['../../node_modules/lit-element/']['lit-html/lit-html.js'], '../../node_modules/lit-html/lit-html.js');

--- a/test/providers/unpkg.test.js
+++ b/test/providers/unpkg.test.js
@@ -9,7 +9,9 @@ const generator = new Generator({
 
 await generator.install('lit@2.0.0-rc.1');
 const json = generator.getMap();
+
 assert.strictEqual(json.imports.lit, 'https://unpkg.com/lit@2.0.0-rc.1/index.js');
+
 const scope = json.scopes['https://unpkg.com/'];
 assert.ok(scope['@lit/reactive-element']);
 assert.ok(scope['lit-element/lit-element.js']);

--- a/test/runMochaTests.js
+++ b/test/runMochaTests.js
@@ -30,7 +30,6 @@ setInterval(() => {
       if (name.startsWith('deno'))
         continue;
       test(name, async function () {
-        console.log(name);
         await import('./' + name + '.js');
       });
     }


### PR DESCRIPTION
This adds a `nodemodules` default provider which does a local node_modules lookup.

This actually works in the browser so long as the `node_modules/` fetch doesn't return a 404 (eg if it returns a listing page like a local server would). Otherwise it always works on the local file system too.

Tested with lit-element and seems like it works...!

Resolves https://github.com/jspm/generator/issues/21.

//cc @daKmoR