### PR TITLE
Support rootUrl option, docs refactor

### DIFF
--- a/src/common/url.ts
+++ b/src/common/url.ts
@@ -29,12 +29,18 @@ export function importedFrom (parentUrl?: string | URL) {
   return ` imported from ${parentUrl}`;
 }
 
-export function relativeUrl (url: URL, baseUrl: URL) {
+function matchesRoot (url: URL, baseUrl: URL) {
+  return url.protocol === baseUrl.protocol && url.host === baseUrl.host && url.port === baseUrl.port && url.username === baseUrl.username && url.password === baseUrl.password;
+}
+
+export function relativeUrl (url: URL, baseUrl: URL, absolute = false) {
   const href = url.href;
   const baseUrlHref = baseUrl.href;
   if (href.startsWith(baseUrlHref))
-    return './' + href.slice(baseUrlHref.length);
-  if (url.protocol !== baseUrl.protocol || url.host !== baseUrl.host || url.port !== baseUrl.port || url.username !== baseUrl.username || url.password !== baseUrl.password)
+    return (absolute ? '/' : './') + href.slice(baseUrlHref.length);
+  if (!matchesRoot(url, baseUrl))
+    return url.href;
+  if (absolute)
     return url.href;
   const baseUrlPath = baseUrl.pathname;
   const urlPath = url.pathname;

--- a/src/tracemap/map.ts
+++ b/src/tracemap/map.ts
@@ -173,7 +173,7 @@ export class ImportMap implements IImportMap {
     return this;
   }
 
-  rebase (newBaseUrl: string = this.baseUrl.href) {
+  rebase (newBaseUrl: string = this.baseUrl.href, abs = false) {
     const oldBaseUrl = this.baseUrl;
     this.baseUrl = new URL(newBaseUrl, baseUrl);
     if (!this.baseUrl.pathname.endsWith('/')) this.baseUrl.pathname += '/';
@@ -181,10 +181,10 @@ export class ImportMap implements IImportMap {
     for (const impt of Object.keys(this.imports)) {
       const target = this.imports[impt];
       if (target !== null && target[0] !== '/')
-        this.imports[impt] = relativeUrl(new URL(target, oldBaseUrl), this.baseUrl);
+        this.imports[impt] = relativeUrl(new URL(target, oldBaseUrl), this.baseUrl, abs);
     }
     for (const scope of Object.keys(this.scopes)) {
-      const newScope = relativeUrl(new URL(scope, oldBaseUrl), this.baseUrl);
+      const newScope = relativeUrl(new URL(scope, oldBaseUrl), this.baseUrl, abs);
       const scopeImports = this.scopes[scope];
       if (scope !== newScope) {
         delete this.scopes[scope];
@@ -193,23 +193,23 @@ export class ImportMap implements IImportMap {
       for (const name of Object.keys(scopeImports)) {
         const target = scopeImports[name];
         if (target !== null && target[0] !== '/')
-          scopeImports[name] = relativeUrl(new URL(target, oldBaseUrl), this.baseUrl);
+          scopeImports[name] = relativeUrl(new URL(target, oldBaseUrl), this.baseUrl, abs);
       }
     }
     const newDepcache = Object.create(null);
     for (const dep of Object.keys(this.depcache)) {
       const importsRebased = this.depcache[dep].map(specifier => {
         if (isPlain(specifier)) return specifier;
-        return relativeUrl(new URL(specifier, oldBaseUrl), this.baseUrl);
+        return relativeUrl(new URL(specifier, oldBaseUrl), this.baseUrl, abs);
       });
-      const depRebased = relativeUrl(new URL(dep, oldBaseUrl), this.baseUrl);
+      const depRebased = relativeUrl(new URL(dep, oldBaseUrl), this.baseUrl, abs);
       newDepcache[depRebased] = importsRebased;
     }
     this.depcache = newDepcache;
     const newIntegrity = Object.create(null);
     for (const dep of Object.keys(this.integrity)) {
       const integrityVal = this.integrity[dep];
-      const depRebased = relativeUrl(new URL(dep, oldBaseUrl), this.baseUrl);
+      const depRebased = relativeUrl(new URL(dep, oldBaseUrl), this.baseUrl, abs);
       newIntegrity[depRebased] = integrityVal;
     }
     this.integrity = newIntegrity;

--- a/test/api/rooturl.test.js
+++ b/test/api/rooturl.test.js
@@ -1,0 +1,13 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+const generator = new Generator({
+  mapUrl: import.meta.url,
+  rootUrl: new URL('./', import.meta.url),
+  env: ['production', 'browser']
+});
+
+await generator.install({ target: './local/pkg', subpath: './custom' });
+const json = generator.getMap();
+
+assert.strictEqual(json.imports['localpkg/custom'], '/local/pkg/a.js');


### PR DESCRIPTION
This resolves https://github.com/jspm/generator/issues/25, adding a `rootUrl` option which then takes precedence over the `mapUrl` option and forcing absolute paths.