### PR TITLE
Resolve method, expose fetch

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,6 +84,11 @@ console.log(JSON.stringify(generator.getMap(), null, 2));
  *   "scopes": { ... }
  * }
  */
+
+// Once packages are installed, the resolve function provides direct import map resolutions:
+
+// https://ga.jspm.io/npm:lit@2.0.0-rc.1/decorators.js
+console.log(generator.resolve('lib/decorators.js'/*, optionalScopeUrl */));
 ```
 
 The `"scopes"` field is populated with all necessary deep dependencies with versions deduped and shared as
@@ -291,6 +296,19 @@ Example:
 import { clearCache } from '@jspm/generator';
 clearCache();
 ```
+
+#### fetch
+
+_Use the internal fetch implementation, useful for hooking into the same shared local fetch cache._
+
+```js
+import { fetch } from '@jspm/generator';
+
+const res = await fetch(url);
+console.log(await res.text());
+```
+
+Use the `{ cache: 'no-store' }` option to disable the cache, and the `{ cache: 'force-cache' }` option to enforce the offline cache.
 
 #### getPackageConfig
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,9 +1,9 @@
 import { baseUrl } from "./common/url.js";
 import { ExactPackage, toPackageTarget } from "./install/package.js";
 import TraceMap from './tracemap/tracemap.js';
-import { InstallTarget, LockResolutions } from './install/installer.js';
+import { LockResolutions } from './install/installer.js';
 // @ts-ignore
-import { clearCache as clearFetchCache } from '#fetch';
+import { clearCache as clearFetchCache, fetch as _fetch } from '#fetch';
 import { createLogger, LogStream } from './common/log.js';
 import { Resolver } from "./install/resolver.js";
 
@@ -108,6 +108,13 @@ export class Generator {
     }
   }
 
+  // resolver that uses the internal import map
+  resolve (specifier: string, parentUrl: URL | string = baseUrl) {
+    if (typeof parentUrl === 'string')
+      parentUrl = new URL(parentUrl, baseUrl);
+    return this.traceMap.map.resolve(specifier, parentUrl).href;
+  }
+
   getMap () {
     const map = this.traceMap.map.clone();
     map.flatten();
@@ -123,6 +130,11 @@ export class Generator {
 export interface LookupOptions {
   provider?: string;
   cache?: 'offline' | boolean;
+}
+
+export async function fetch (url: string, opts: any) {
+  // @ts-ignore
+  return _fetch(url, opts);
 }
 
 export async function lookup (install: string | Install, { provider, cache }: LookupOptions = {}) {

--- a/src/tracemap/map.ts
+++ b/src/tracemap/map.ts
@@ -251,20 +251,15 @@ export class ImportMap implements IImportMap {
   }
 }
 
-const scopeCache = new WeakMap<Record<string, Record<string, string | null>>, [string, string][]>();
 export function getScopeMatches (parentUrl: URL, scopes: Record<string, Record<string, string | null>>, baseUrl: URL): [string, string][] {
   const parentUrlHref = parentUrl.href;
 
-  let scopeCandidates = scopeCache.get(scopes);
-  if (!scopeCandidates) {
-    scopeCandidates = Object.keys(scopes).map(scope => [scope, new URL(scope, baseUrl).href]);
-    scopeCandidates = scopeCandidates.sort(([, matchA], [, matchB]) => matchA.length < matchB.length ? 1 : -1);
-    scopeCache.set(scopes, scopeCandidates);
-  }
+  let scopeCandidates = Object.keys(scopes).map(scope => [scope, new URL(scope, baseUrl).href]);
+  scopeCandidates = scopeCandidates.sort(([, matchA], [, matchB]) => matchA.length < matchB.length ? 1 : -1);
 
   return scopeCandidates.filter(([, scopeUrl]) => {
     return scopeUrl === parentUrlHref || scopeUrl.endsWith('/') && parentUrlHref.startsWith(scopeUrl);
-  });
+  }) as [string, string][];
 }
 
 export function getMapMatch<T = any> (specifier: string, map: Record<string, T>): string | undefined {

--- a/test/utils/fetch.test.js
+++ b/test/utils/fetch.test.js
@@ -1,0 +1,5 @@
+import { fetch } from '@jspm/generator';
+import assert from 'assert';
+
+const pcfg = await (await fetch('https://ga.jspm.io/npm:jquery@3.6.0/package.json')).json();
+assert.strictEqual(pcfg.name, 'jquery');

--- a/test/utils/resolve.test.js
+++ b/test/utils/resolve.test.js
@@ -1,0 +1,13 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+const generator = new Generator({
+  mapUrl: import.meta.url
+});
+
+await generator.install('@jspm/generator');
+
+const generatorUrl = new URL('../../dist/generator.js', import.meta.url).href;
+
+assert.strictEqual(generator.resolve('@jspm/generator'), generatorUrl);
+assert.strictEqual(generator.resolve('#fetch', generatorUrl), new URL('./fetch.js', generatorUrl).href);


### PR DESCRIPTION
This adds two new utility methods:

1. Exposing the cached `fetch` hook via `import { fetch } from '@jspm/generator'`
2. Exposing the import map resolver via `generator.resolve()` as a sync function.

This will make it easier to construct build tools that want to wrap the generator.