### PR TITLE
feat: Support custom providers as an option

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -7,6 +7,7 @@ import { clearCache as clearFetchCache, fetch as _fetch } from '#fetch';
 import { createLogger, LogStream } from './common/log.js';
 import { Resolver } from "./install/resolver.js";
 import { IImportMap } from "./tracemap/map";
+import { Provider } from "./providers/index.js";
 
 export interface GeneratorOptions {
   mapUrl?: URL | string;
@@ -19,6 +20,7 @@ export interface GeneratorOptions {
   env?: string[];
   cache?: 'offline' | boolean;
   stdlib?: string;
+  customProviders?: Record<string, Provider>;
 }
 
 export interface Install {
@@ -47,6 +49,7 @@ export class Generator {
     inputMap = undefined,
     env = ['browser', 'development', 'module'],
     defaultProvider = 'jspm',
+    customProviders = undefined,
     cache = true,
     stdlib = '@jspm/core'
   }: GeneratorOptions = {}) {
@@ -57,6 +60,11 @@ export class Generator {
       fetchOpts = { cache: 'no-store' };
     const { log, logStream } = createLogger();
     const resolver = new Resolver(log, fetchOpts);
+    if (customProviders) {
+      for (const provider of Object.keys(customProviders)) {
+        resolver.addCustomProvider(provider, customProviders[provider]);
+      }
+    }
     this.logStream = logStream;
     this.mapUrl = typeof mapUrl === 'string' ? new URL(mapUrl, baseUrl) : mapUrl;
     this.rootUrl = typeof rootUrl === 'string' ? new URL(rootUrl, baseUrl) : rootUrl || null;

--- a/src/install/package.ts
+++ b/src/install/package.ts
@@ -40,6 +40,12 @@ export interface PackageTarget {
   ranges: any[];
 }
 
+export interface LatestPackageTarget {
+  registry: string;
+  name: string;
+  range: any;
+}
+
 const supportedProtocols = ['https', 'http', 'data', 'file'];
 export async function parseUrlTarget (resolver: Resolver, targetStr: string, parentUrl?: string): Promise<{ alias: string, target: URL, subpath: '.' | `./${string}` } | undefined> {
   const registryIndex = targetStr.indexOf(':');

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -3,20 +3,20 @@ import * as skypack from './skypack.js';
 import * as jsdelivr from './jsdelivr.js';
 import * as unpkg from './unpkg.js';
 import * as nodemodules from './nodemodules.js';
-import { PackageConfig, ExactPackage } from '../install/package.js';
+import { PackageConfig, ExactPackage, LatestPackageTarget } from '../install/package.js';
 import { Resolver } from '../install/resolver.js';
 import { PackageTarget } from '../install/package.js';
 
 export interface Provider {
-  name: string;
   parseUrlPkg (this: Resolver, url: string): ExactPackage | { pkg: ExactPackage, layer: string } | undefined;
   pkgToUrl (this: Resolver, pkg: ExactPackage, layer: string): string;
+  resolveLatestTarget (this: Resolver, target: LatestPackageTarget, unstable: boolean, layer: string, parentUrl: string): Promise<ExactPackage | null>;
+
   getPackageConfig? (this: Resolver, pkgUrl: string): Promise<PackageConfig | null | undefined>;
-  resolveLatestTarget (this: Resolver, target: PackageTarget, unstable: boolean, layer: string, parentUrl: string): Promise<ExactPackage | null>;
-  getFileList? (this: Resolver, pkgUrl: string): Promise<string[]>;
+  // getFileList? (this: Resolver, pkgUrl: string): Promise<string[]>;
 }
 
-export const providers: Record<string, Provider> = {
+export const defaultProviders: Record<string, Provider> = {
   jsdelivr,
   jspm,
   nodemodules,
@@ -24,7 +24,7 @@ export const providers: Record<string, Provider> = {
   unpkg
 };
 
-export function getProvider (name: string) {
+export function getProvider (name: string, providers: Record<string, Provider> = defaultProviders) {
   const provider = providers[name];
   if (provider)
     return provider;

--- a/src/providers/jsdelivr.ts
+++ b/src/providers/jsdelivr.ts
@@ -1,7 +1,5 @@
 import { ExactPackage } from "../install/package.js";
 
-export const name = 'jsdelivr';
-
 const cdnUrl = 'https://cdn.jsdelivr.net/';
 
 export function pkgToUrl (pkg: ExactPackage) {

--- a/src/providers/nodemodules.ts
+++ b/src/providers/nodemodules.ts
@@ -1,12 +1,10 @@
-import { PackageTarget } from "../install/package.js";
+import { LatestPackageTarget, PackageTarget } from "../install/package.js";
 import { ExactPackage } from "../install/package.js";
 import { Resolver } from "../install/resolver.js";
 // @ts-ignore
 import { fetch } from '#fetch';
 import { JspmError } from "../common/err.js";
 import { importedFrom } from "../common/url.js";
-
-export const name = 'nodemodules';
 
 export function pkgToUrl (pkg: ExactPackage) {
   return new URL(pkg.version + pkg.name + '/').href;
@@ -35,7 +33,7 @@ async function dirExists (url: URL, parentUrl?: string) {
   }
 }
 
-export async function resolveLatestTarget (this: Resolver, target: PackageTarget, _unstable: boolean, _layer: string, parentUrl: string): Promise<ExactPackage | null> {
+export async function resolveLatestTarget (this: Resolver, target: LatestPackageTarget, _unstable: boolean, _layer: string, parentUrl: string): Promise<ExactPackage | null> {
   let curUrl = new URL('node_modules/', parentUrl);
   const rootUrl = new URL('/node_modules/', parentUrl).href;
   while (!(await dirExists.call(this, curUrl))) {

--- a/src/providers/skypack.ts
+++ b/src/providers/skypack.ts
@@ -1,7 +1,5 @@
 import { ExactPackage } from "../install/package.js";
 
-export const name = 'skypack';
-
 const cdnUrl = 'https://cdn.skypack.dev/';
 
 export function pkgToUrl (pkg: ExactPackage) {

--- a/src/providers/unpkg.ts
+++ b/src/providers/unpkg.ts
@@ -1,7 +1,5 @@
 import { ExactPackage } from "../install/package.js";
 
-export const name = 'unpkg';
-
 const cdnUrl = 'https://unpkg.com/';
 
 export function pkgToUrl (pkg: ExactPackage) {

--- a/test/providers/custom.test.js
+++ b/test/providers/custom.test.js
@@ -1,0 +1,31 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+const unpkgUrl = 'https://unpkg.com/';
+const exactPkgRegEx = /^((?:@[^/\\%@]+\/)?[^./\\%@][^/\\%@]*)@([^\/]+)(\/.*)?$/;
+
+const generator = new Generator({
+  defaultProvider: 'custom',
+  customProviders: {
+    custom: {
+      pkgToUrl ({ registry, name, version }) {
+        return `${unpkgUrl}${name}@${version}/`;
+      },
+      parseUrlPkg (url) {
+        if (url.startsWith(unpkgUrl)) {
+          const [, name, version] = url.slice(unpkgUrl.length).match(exactPkgRegEx) || [];
+          return { registry: 'npm', name, version };
+        }
+      },
+      resolveLatestTarget ({ registry, name, range }, unstable, layer, parentUrl) {
+        return { registry, name, version: '3.6.0' };
+      }
+    }
+  }
+});
+
+await generator.install('custom:jquery');
+
+const json = generator.getMap();
+
+assert.strictEqual(json.imports.jquery, 'https://unpkg.com/jquery@3.6.0/dist/jquery.js');


### PR DESCRIPTION
This adds a new `customProviders` option which allows easily passing in custom provider definitions.

Includes tests and documentation.

//cc @vovacodes 