### PR TITLE
CJS Tracing, traceInstall, getAnalysis

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,9 +92,9 @@ console.log(JSON.stringify(generator.getMap(), null, 2));
  * }
  */
 
-// Returns the @jspm/import-map class for the map
-const map = generator.getMapInstance();
-map.resolve('lit/html.js');
+// generator.importMap returns the internal import map instance,
+// with API per the @jspm/import-map package
+const map = generator.importMap.resolve('lit/html.js);
 // -> https://ga.jspm.io/npm:lit@2.0.0-rc.1/html.js
 
 // Once packages are installed, the resolve function provides direct import map resolutions:

--- a/README.md
+++ b/README.md
@@ -92,6 +92,10 @@ console.log(JSON.stringify(generator.getMap(), null, 2));
  * }
  */
 
+// Instead of installing, an entry point module can be traced directly
+// Then all of its dependencies will be installed into the map only as needed
+await generator.traceInstall('./app.js');
+
 // generator.importMap returns the internal import map instance,
 // with API per the @jspm/import-map package
 const map = generator.importMap.resolve('lit/html.js);

--- a/package.json
+++ b/package.json
@@ -33,20 +33,21 @@
     "default": "./dist/generator.js"
   },
   "dependencies": {
+    "@babel/core": "^7.14.8",
     "@jspm/import-map": "^0.1.4",
     "es-module-lexer": "^0.4.1",
-    "kleur": "^4.1.4",
     "make-fetch-happen": "^8.0.3",
-    "mocha": "^9.0.0",
-    "open": "^8.2.0",
     "sver": "^1.8.3"
   },
   "devDependencies": {
     "chalk": "^4.1.1",
     "cross-env": "^7.0.2",
+    "kleur": "^4.1.4",
     "lit-element": "^2.5.1",
+    "mocha": "^9.0.0",
+    "open": "^8.2.0",
     "rollup": "^2.44.0",
-    "typescript": "^4.1.3"
+    "typescript": "^4.3.5"
   },
   "files": [
     "dist"

--- a/src/common/integrity.ts
+++ b/src/common/integrity.ts
@@ -1,8 +1,0 @@
-// import * as crypto from 'crypto';
-
-export function computeIntegrity (_source: string) {
-  return '';
-  // const hash = crypto.createHash('sha384');
-  // hash.update(source);
-  // return 'sha384-' + hash.digest('base64');
-}

--- a/src/generator.d.ts
+++ b/src/generator.d.ts
@@ -22,6 +22,12 @@ export interface IImportMap {
   scopes?: Record<string, Record<string, string>>;
 }
 
+export interface ExactPackage {
+  registry: string;
+  name: string;
+  version: string;
+}
+
 export declare class Generator {
   logStream: LogStream;
   constructor ({ mapUrl, env, defaultProvider, cache, stdlib }?: GeneratorOptions);
@@ -29,8 +35,8 @@ export declare class Generator {
     staticDeps: string[];
     dynamicDeps: string[];
   }>;
+  importMap: ImportMap;
   getMap (): IImportMap;
-  getMapInstance (): ImportMap;
 }
 
 export interface LookupOptions {

--- a/src/generator.d.ts
+++ b/src/generator.d.ts
@@ -1,4 +1,5 @@
 import { ImportMap } from '@jspm/import-map';
+import { NonRelativeModuleNameResolutionCache } from 'typescript';
 
 export type LogStream = () => AsyncGenerator<{ type: string, message: string }, never, unknown>;
 
@@ -37,6 +38,14 @@ export declare class Generator {
   }>;
   importMap: ImportMap;
   getMap (): IImportMap;
+  getAnalysis (url: string | URL): ModuleAnalysis;
+}
+
+export interface ModuleAnalysis {
+  format: 'commonjs' | 'esm' | 'system';
+  staticDeps: string[];
+  dynamicDeps: string[];
+  cjsLazyDeps: string[] | null;
 }
 
 export interface LookupOptions {

--- a/src/generator.d.ts
+++ b/src/generator.d.ts
@@ -39,6 +39,10 @@ export declare class Generator {
   importMap: ImportMap;
   getMap (): IImportMap;
   getAnalysis (url: string | URL): ModuleAnalysis;
+  traceInstall (specifier: string, parentUrl?: string | URL): Promise<{
+    staticDeps: string[];
+    dynamicDeps: string[];
+  }>;
 }
 
 export interface ModuleAnalysis {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -24,6 +24,13 @@ export interface GeneratorOptions {
   customProviders?: Record<string, Provider>;
 }
 
+export interface ModuleAnalysis {
+  format: 'commonjs' | 'esm' | 'system';
+  staticDeps: string[];
+  dynamicDeps: string[];
+  cjsLazyDeps: string[] | null;
+}
+
 export interface Install {
   target: string;
   subpath?: '.' | `./${string}`;
@@ -136,6 +143,20 @@ export class Generator {
 
   get importMap () {
     return this.traceMap.map;
+  }
+
+  getAnalysis (url: string | URL): ModuleAnalysis {
+    if (typeof url !== 'string')
+      url = url.href;
+    const trace = this.traceMap.tracedUrls[url];
+    if (!trace)
+      throw new Error(`The URL ${url} has not been traced by this generator instance.`);
+    return {
+      format: trace.format,
+      staticDeps: Object.keys(trace.deps),
+      dynamicDeps: Object.keys(trace.dynamicDeps),
+      cjsLazyDeps: trace.cjsLazyDeps
+    };
   }
 
   getMap () {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,11 +1,11 @@
 import { baseUrl } from "./common/url.js";
 import { ExactPackage, toPackageTarget } from "./install/package.js";
-import TraceMap from './tracemap/tracemap.js';
+import TraceMap from './trace/tracemap.js';
 import { LockResolutions } from './install/installer.js';
 // @ts-ignore
 import { clearCache as clearFetchCache, fetch as _fetch } from '#fetch';
 import { createLogger, LogStream } from './common/log.js';
-import { Resolver } from "./install/resolver.js";
+import { Resolver } from "./trace/resolver.js";
 import { IImportMap } from "@jspm/import-map";
 import { Provider } from "./providers/index.js";
 import { JspmError } from "./common/err.js";
@@ -134,14 +134,8 @@ export class Generator {
     return resolved;
   }
 
-  getMapInstance () {
-    const map = this.traceMap.map.clone();
-    if (this.rootUrl)
-      map.rebase(this.rootUrl.href, true);
-    else
-      map.rebase();
-    map.sort();
-    return map;
+  get importMap () {
+    return this.traceMap.map;
   }
 
   getMap () {

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -2,7 +2,7 @@
 import sver from 'sver';
 const { Semver } = sver;
 import { Log } from '../common/log.js';
-import { Resolver } from "./resolver.js";
+import { Resolver } from "../trace/resolver.js";
 import { ExactPackage, newPackageTarget, PackageTarget } from "./package.js";
 import { isURL, importedFrom } from "../common/url.js";
 import { JspmError, throwInternalError } from "../common/err.js";

--- a/src/install/package.ts
+++ b/src/install/package.ts
@@ -5,7 +5,7 @@ import sver from 'sver';
 // @ts-ignore
 import convertRange from 'sver/convert-range.js';
 import { InstallTarget } from "./installer.js";
-import { Resolver } from "./resolver.js";
+import { Resolver } from "../trace/resolver.js";
 import { urlToNiceStr } from "../common/url.js";
 
 const { SemverRange } = sver;

--- a/src/install/pjson.ts
+++ b/src/install/pjson.ts
@@ -1,7 +1,7 @@
 import * as json from "../common/json.js";
 // @ts-ignore
 import { readFileSync, writeFileSync } from "fs";
-import { Resolver } from "../install/resolver.js";
+import { Resolver } from "../trace/resolver.js";
 import { PackageConfig } from "../install/package.js";
 
 export type DependenciesField = 'dependencies' | 'devDependencies' | 'peerDependencies' | 'optionalDependencies';

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -4,8 +4,7 @@ import * as jsdelivr from './jsdelivr.js';
 import * as unpkg from './unpkg.js';
 import * as nodemodules from './nodemodules.js';
 import { PackageConfig, ExactPackage, LatestPackageTarget } from '../install/package.js';
-import { Resolver } from '../install/resolver.js';
-import { PackageTarget } from '../install/package.js';
+import { Resolver } from '../trace/resolver.js';
 
 export interface Provider {
   parseUrlPkg (this: Resolver, url: string): ExactPackage | { pkg: ExactPackage, layer: string } | undefined;

--- a/src/providers/jspm.ts
+++ b/src/providers/jspm.ts
@@ -4,7 +4,7 @@ import { importedFrom } from "../common/url.js";
 import { LatestPackageTarget } from "../install/package.js";
 import { pkgToStr } from "../install/package.js";
 import { ExactPackage } from "../install/package.js";
-import { Resolver } from "../install/resolver.js";
+import { Resolver } from "../trace/resolver.js";
 // @ts-ignore
 import { fetch } from '#fetch';
 

--- a/src/providers/nodemodules.ts
+++ b/src/providers/nodemodules.ts
@@ -1,6 +1,6 @@
-import { LatestPackageTarget, PackageTarget } from "../install/package.js";
+import { LatestPackageTarget } from "../install/package.js";
 import { ExactPackage } from "../install/package.js";
-import { Resolver } from "../install/resolver.js";
+import { Resolver } from "../trace/resolver.js";
 // @ts-ignore
 import { fetch } from '#fetch';
 import { JspmError } from "../common/err.js";

--- a/src/trace/analysis.ts
+++ b/src/trace/analysis.ts
@@ -1,0 +1,74 @@
+export interface Analysis {
+  deps: string[];
+  dynamicDeps: string[];
+  cjsHoistedDeps: string[] | null;
+  format: 'esm' | 'commonjs' | 'system';
+  size: number;
+}
+
+export async function parseTs (source: string) {
+  const { default: ts } = await import(eval('"typescript"'));
+  return ts.transpileModule(source, {
+    compilerOptions: {
+      jsx: ts.JsxEmit.React,
+      module: ts.ModuleKind.ESNext
+    }
+  }).outputText;
+}
+
+export function createEsmAnalysis (imports: any[], source: string, url: string): Analysis {
+  if (!imports.length && registerRegEx.test(source))
+    return createSystemAnalysis(source, imports, url);  
+  const deps: string[] = [];
+  const dynamicDeps: string[] = [];
+  for (const impt of imports) {
+    if (impt.d === -1) {
+      deps.push(source.slice(impt.s, impt.e));
+      continue;
+    }
+    // dynamic import -> deoptimize trace all dependencies (and all their exports)
+    if (impt.d >= 0) {
+      const dynExpression = source.slice(impt.s, impt.e);
+      if (dynExpression.startsWith('"') || dynExpression.startsWith('\'')) {
+        try {
+          dynamicDeps.push(JSON.parse('"' + dynExpression.slice(1, -1) + '"'));
+        }
+        catch (e) {
+          console.warn('TODO: Dynamic import custom expression tracing.');
+        }
+      }
+    }
+  }
+  const size = source.length;
+  return { deps, dynamicDeps, cjsHoistedDeps: null, size, format: 'esm' };
+}
+
+const registerRegEx = /^\s*(\/\*[^\*]*(\*(?!\/)[^\*]*)*\*\/|\s*\/\/[^\n]*)*\s*System\s*\.\s*register\s*\(\s*(\[[^\]]*\])\s*,\s*\(?function\s*\(\s*([^\),\s]+\s*(,\s*([^\),\s]+)\s*)?\s*)?\)/;
+export function createSystemAnalysis (source: string, imports: string[], url: string): Analysis {
+  const [, , , rawDeps, , , contextId] = source.match(registerRegEx) || [];
+  if (!rawDeps)
+    return createEsmAnalysis(imports, source, url);
+  const deps = JSON.parse(rawDeps.replace(/'/g, '"'));
+  const dynamicDeps: string[] = [];
+  if (contextId) {
+    const dynamicImport = `${contextId}.import(`;
+    let i = -1;
+    while ((i = source.indexOf(dynamicImport, i + 1)) !== -1) {
+      const importStart = i + dynamicImport.length + 1;
+      const quote = source[i + dynamicImport.length];
+      if (quote === '"' || quote === '\'') {
+        const importEnd = source.indexOf(quote, i + dynamicImport.length + 1);
+        if (importEnd !== -1) {
+          try {
+            dynamicDeps.push(JSON.parse('"' + source.slice(importStart, importEnd) + '"'));
+            continue;
+          }
+          catch (e) {}
+        }
+      }
+      console.warn('TODO: Dynamic import custom expression tracing.');
+    }
+  }
+  const size = source.length;
+  return { deps, dynamicDeps, cjsHoistedDeps: null, size, format: 'system' };
+}

--- a/src/trace/analysis.ts
+++ b/src/trace/analysis.ts
@@ -1,7 +1,7 @@
 export interface Analysis {
   deps: string[];
   dynamicDeps: string[];
-  cjsHoistedDeps: string[] | null;
+  cjsLazyDeps: string[] | null;
   format: 'esm' | 'commonjs' | 'system';
   size: number;
 }
@@ -40,7 +40,7 @@ export function createEsmAnalysis (imports: any[], source: string, url: string):
     }
   }
   const size = source.length;
-  return { deps, dynamicDeps, cjsHoistedDeps: null, size, format: 'esm' };
+  return { deps, dynamicDeps, cjsLazyDeps: null, size, format: 'esm' };
 }
 
 const registerRegEx = /^\s*(\/\*[^\*]*(\*(?!\/)[^\*]*)*\*\/|\s*\/\/[^\n]*)*\s*System\s*\.\s*register\s*\(\s*(\[[^\]]*\])\s*,\s*\(?function\s*\(\s*([^\),\s]+\s*(,\s*([^\),\s]+)\s*)?\s*)?\)/;
@@ -70,5 +70,5 @@ export function createSystemAnalysis (source: string, imports: string[], url: st
     }
   }
   const size = source.length;
-  return { deps, dynamicDeps, cjsHoistedDeps: null, size, format: 'system' };
+  return { deps, dynamicDeps, cjsLazyDeps: null, size, format: 'system' };
 }

--- a/src/trace/cjs.ts
+++ b/src/trace/cjs.ts
@@ -1,0 +1,117 @@
+import { Analysis } from "./analysis";
+
+export async function createCjsAnalysis (imports: any, source: string, url: string): Promise<Analysis> {
+  const { default: babel } = await import(eval('"@babel/core"'));
+
+  const requires = new Set<string>();
+  const hoisted = new Set<string>();
+
+  const { ast: _ast } = babel.transform(source, {
+    ast: true,
+    sourceMaps: false,
+    inputSourceMap: false,
+    babelrc: false,
+    babelrcRoots: false,
+    configFile: false,
+    highlightCode: false,
+    compact: false,
+    sourceType: 'script',
+    parserOpts: {
+      allowReturnOutsideFunction: true,
+      // plugins: stage3Syntax,
+      errorRecovery: true
+    },
+    plugins: [({ types: t }) => {
+      return {
+        visitor: {
+          Program (path, state) {
+            state.functionDepth = 0;
+          },
+          CallExpression (path, state) {
+            if (t.isIdentifier(path.node.callee, { name: 'require' }) ||
+                t.isIdentifier(path.node.callee.object, { name: 'require' }) &&
+                t.isIdentifier(path.node.callee.property, { name: 'resolve' }) ||
+                t.isMemberExpression(path.node.callee) &&
+                t.isIdentifier(path.node.callee.object, { name: 'module' }) &&
+                t.isIdentifier(path.node.callee.property, { name: 'require' })) {
+              const req = buildDynamicString(path.get('arguments.0').node, url);
+              requires.add(req);
+              if (state.functionDepth > 0)
+                hoisted.add(req);
+            }
+          },
+          Scope: {
+            enter (path, state) {
+              if (t.isFunction(path.scope.block))
+                state.functionDepth++;
+            },
+            exit (path, state) {
+              if (t.isFunction(path.scope.block))
+                state.functionDepth--;
+            }
+          },
+          // Import (path) {
+          //   dynamicImports.add(buildDynamicString(path.parentPath.get('arguments.0').node, url, true));
+          // }
+        }
+      };
+    }]
+  });
+
+  return {
+    deps: [...requires],
+    dynamicDeps: imports.filter(impt => impt.n).map(impt => impt.n),
+    cjsHoistedDeps: [...hoisted],
+    size: source.length,
+    format: 'commonjs'
+  };
+}
+
+function buildDynamicString (node, fileName, isEsm = false, lastIsWildcard = false): string {
+  if (node.type === 'StringLiteral') {
+    return node.value;
+  }
+  if (node.type === 'TemplateLiteral') {
+    let str = '';
+    for (let i = 0; i < node.quasis.length; i++) {
+      const quasiStr = node.quasis[i].value.cooked;
+      if (quasiStr.length) {
+        str += quasiStr;
+        lastIsWildcard = false;
+      }
+      const nextNode = node.expressions[i];
+      if (nextNode) {
+        const nextStr = buildDynamicString(nextNode, fileName, isEsm, lastIsWildcard);
+        if (nextStr.length) {
+          lastIsWildcard = nextStr.endsWith('*');
+          str += nextStr;
+        }
+      }
+    }
+    return str;
+  }
+  if (node.type === 'BinaryExpression' && node.operator === '+') {
+    const leftResolved = buildDynamicString(node.left, fileName, isEsm, lastIsWildcard);
+    if (leftResolved.length)
+      lastIsWildcard = leftResolved.endsWith('*');
+    const rightResolved = buildDynamicString(node.right, fileName, isEsm, lastIsWildcard);
+    return leftResolved + rightResolved;
+  }
+  if (node.type === 'Identifier') {
+    if (node.name === '__dirname')
+      return '.';
+    if (node.name === '__filename')
+      return './' + fileName;
+  }
+  // TODO: proper expression support
+  // new URL('...', import.meta.url).href | new URL('...', import.meta.url).toString() | new URL('...', import.meta.url).pathname
+  // import.meta.X
+  /*if (isEsm && node.type === 'MemberExpression' && node.object.type === 'MetaProperty' &&
+      node.object.meta.type === 'Identifier' && node.object.meta.name === 'import' &&
+      node.object.property.type === 'Identifier' && node.object.property.name === 'meta') {
+    if (node.property.type === 'Identifier' && node.property.name === 'url') {
+      return './' + fileName;
+    }
+  }*/
+  return lastIsWildcard ? '' : '*';
+}

--- a/src/trace/cjs.ts
+++ b/src/trace/cjs.ts
@@ -4,7 +4,7 @@ export async function createCjsAnalysis (imports: any, source: string, url: stri
   const { default: babel } = await import(eval('"@babel/core"'));
 
   const requires = new Set<string>();
-  const hoisted = new Set<string>();
+  const lazy = new Set<string>();
 
   const { ast: _ast } = babel.transform(source, {
     ast: true,
@@ -37,7 +37,7 @@ export async function createCjsAnalysis (imports: any, source: string, url: stri
               const req = buildDynamicString(path.get('arguments.0').node, url);
               requires.add(req);
               if (state.functionDepth > 0)
-                hoisted.add(req);
+                lazy.add(req);
             }
           },
           Scope: {
@@ -61,7 +61,7 @@ export async function createCjsAnalysis (imports: any, source: string, url: stri
   return {
     deps: [...requires],
     dynamicDeps: imports.filter(impt => impt.n).map(impt => impt.n),
-    cjsHoistedDeps: [...hoisted],
+    cjsLazyDeps: [...lazy],
     size: source.length,
     format: 'commonjs'
   };

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -39,7 +39,7 @@ interface TraceEntry {
   wasCJS: boolean;
   // For cjs modules, the list of hoisted deps
   // this is needed for proper cycle handling
-  cjsHoistedDeps: string[];
+  cjsLazyDeps: string[];
   format: 'esm' | 'commonjs' | 'system';
 }
 
@@ -308,7 +308,7 @@ export default class TraceMap {
       wasCJS: false,
       deps: Object.create(null),
       dynamicDeps: Object.create(null),
-      cjsHoistedDeps: null,
+      cjsLazyDeps: null,
       hasStaticParent: true,
       size: NaN,
       integrity: '',
@@ -327,11 +327,11 @@ export default class TraceMap {
     if (resolvedUrl.endsWith('/'))
       throw new JspmError(`Trailing "/" installs not yet supported installing ${resolvedUrl} for ${parentUrl.href}`);
     
-    const { deps, dynamicDeps, cjsHoistedDeps, size, format } = await this.resolver.analyze(resolvedUrl, parentUrl, this.opts.system);
+    const { deps, dynamicDeps, cjsLazyDeps, size, format } = await this.resolver.analyze(resolvedUrl, parentUrl, this.opts.system);
     traceEntry.format = format;
     traceEntry.size = size;
-    if (cjsHoistedDeps)
-      traceEntry.cjsHoistedDeps = cjsHoistedDeps;
+    if (cjsLazyDeps)
+      traceEntry.cjsLazyDeps = cjsLazyDeps;
     
     let allDeps: string[] = deps;
     if (dynamicDeps.length && !this.opts.static) {

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -4,7 +4,7 @@ import { Installer } from "../install/installer.js";
 import { JspmError, throwInternalError } from "../common/err.js";
 import { parsePkg } from "../install/package.js";
 import { ImportMap, IImportMap, getMapMatch, getScopeMatches } from '@jspm/import-map';
-import { resolvePackageTarget, Resolver } from "../install/resolver.js";
+import { resolvePackageTarget, Resolver } from "./resolver.js";
 import { Log } from "../common/log.js";
 
 // TODO: options as trace-specific / stored as top-level per top-level load
@@ -37,8 +37,10 @@ interface TraceEntry {
   size: number;
   integrity: string;
   wasCJS: boolean;
-  system: boolean;
-  babel: boolean;
+  // For cjs modules, the list of hoisted deps
+  // this is needed for proper cycle handling
+  cjsHoistedDeps: string[];
+  format: 'esm' | 'commonjs' | 'system';
 }
 
 // The tracemap fully drives the installer
@@ -97,7 +99,7 @@ export default class TraceMap {
     let system = false, esm = false;
     for (const url of [...this.staticList, ...this.dynamicList]) {
       const trace = this.tracedUrls[url];
-      if (trace.system)
+      if (trace.format === 'system')
         system = true;
       else
         esm = true;
@@ -306,11 +308,11 @@ export default class TraceMap {
       wasCJS: false,
       deps: Object.create(null),
       dynamicDeps: Object.create(null),
+      cjsHoistedDeps: null,
       hasStaticParent: true,
       size: NaN,
       integrity: '',
-      system: false,
-      babel: false
+      format: undefined
     };
 
     const wasCJS = await this.resolver.wasCommonJS(resolvedUrl);
@@ -325,10 +327,11 @@ export default class TraceMap {
     if (resolvedUrl.endsWith('/'))
       throw new JspmError(`Trailing "/" installs not yet supported installing ${resolvedUrl} for ${parentUrl.href}`);
     
-    const { deps, dynamicDeps, integrity, size, system } = await this.resolver.analyze(resolvedUrl, parentUrl, this.opts.system);
-    traceEntry.integrity = integrity;
-    traceEntry.system = !!system;
+    const { deps, dynamicDeps, cjsHoistedDeps, size, format } = await this.resolver.analyze(resolvedUrl, parentUrl, this.opts.system);
+    traceEntry.format = format;
     traceEntry.size = size;
+    if (cjsHoistedDeps)
+      traceEntry.cjsHoistedDeps = cjsHoistedDeps;
     
     let allDeps: string[] = deps;
     if (dynamicDeps.length && !this.opts.static) {

--- a/test/api/api.test.js
+++ b/test/api/api.test.js
@@ -12,3 +12,11 @@ const json = generator.getMap();
 assert.strictEqual(json.imports.react, 'https://ga.jspm.io/npm:react@16.14.0/index.js');
 
 assert.strictEqual(generator.importMap.resolve('react'), 'https://ga.jspm.io/npm:react@16.14.0/index.js');
+
+const meta = generator.getAnalysis('https://ga.jspm.io/npm:react@16.14.0/index.js');
+assert.deepStrictEqual(meta, {
+  format: 'esm',
+  staticDeps: ['./cjs/react.production.min.js', 'object-assign'],
+  dynamicDeps: [],
+  cjsLazyDeps: null
+});

--- a/test/api/local/pkg/e.cjs
+++ b/test/api/local/pkg/e.cjs
@@ -1,0 +1,2 @@
+require('#cjsdep');
+import('#cjsdep');

--- a/test/api/local/pkg/f.cjs
+++ b/test/api/local/pkg/f.cjs
@@ -1,0 +1,4 @@
+module.exports = 'f';
+(function () {
+  require('./a.js');
+})();

--- a/test/api/local/pkg/package.json
+++ b/test/api/local/pkg/package.json
@@ -4,7 +4,11 @@
     "./custom": "./a.js",
     "./withdep": "./b.js",
     "./withdep2": "./c.js",
-    "./remotedep": "./d.js"
+    "./remotedep": "./d.js",
+    "./cjs": "./e.cjs"
+  },
+  "imports": {
+    "#cjsdep": "./f.cjs"
   },
   "dependencies": {
     "dep": "file:../dep",

--- a/test/api/localcjs.test.js
+++ b/test/api/localcjs.test.js
@@ -1,17 +1,20 @@
 import { Generator } from '@jspm/generator';
 import assert from 'assert';
 
-const generator = new Generator({
-  mapUrl: import.meta.url,
-  defaultProvider: 'jspm',
-  env: ['production', 'browser']
-});
+// Not supported in browsers
+if (typeof document === 'undefined') {
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'jspm',
+    env: ['production', 'browser']
+  });
 
-await generator.install({ target: './local/pkg', subpath: './cjs' });
-const json = generator.getMap();
+  await generator.install({ target: './local/pkg', subpath: './cjs' });
+  const json = generator.getMap();
 
-assert.strictEqual(json.imports['localpkg/cjs'], './local/pkg/e.cjs');
-assert.strictEqual(json.scopes['./local/pkg/']['#cjsdep'], './local/pkg/f.cjs');
+  assert.strictEqual(json.imports['localpkg/cjs'], './local/pkg/e.cjs');
+  assert.strictEqual(json.scopes['./local/pkg/']['#cjsdep'], './local/pkg/f.cjs');
 
-const meta = generator.getAnalysis(new URL('./local/pkg/f.cjs', import.meta.url));
-assert.deepStrictEqual(meta.cjsLazyDeps, ['./a.js']);
+  const meta = generator.getAnalysis(new URL('./local/pkg/f.cjs', import.meta.url));
+  assert.deepStrictEqual(meta.cjsLazyDeps, ['./a.js']);
+}

--- a/test/api/localcjs.test.js
+++ b/test/api/localcjs.test.js
@@ -12,3 +12,6 @@ const json = generator.getMap();
 
 assert.strictEqual(json.imports['localpkg/cjs'], './local/pkg/e.cjs');
 assert.strictEqual(json.scopes['./local/pkg/']['#cjsdep'], './local/pkg/f.cjs');
+
+const meta = generator.getAnalysis(new URL('./local/pkg/f.cjs', import.meta.url));
+assert.deepStrictEqual(meta.cjsLazyDeps, ['./a.js']);

--- a/test/api/localcjs.test.js
+++ b/test/api/localcjs.test.js
@@ -7,8 +7,8 @@ const generator = new Generator({
   env: ['production', 'browser']
 });
 
-await generator.install('react@16');
+await generator.install({ target: './local/pkg', subpath: './cjs' });
 const json = generator.getMap();
-assert.strictEqual(json.imports.react, 'https://ga.jspm.io/npm:react@16.14.0/index.js');
 
-assert.strictEqual(generator.importMap.resolve('react'), 'https://ga.jspm.io/npm:react@16.14.0/index.js');
+assert.strictEqual(json.imports['localpkg/cjs'], './local/pkg/e.cjs');
+assert.strictEqual(json.scopes['./local/pkg/']['#cjsdep'], './local/pkg/f.cjs');

--- a/test/api/traceinstall.test.js
+++ b/test/api/traceinstall.test.js
@@ -1,0 +1,13 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+const generator = new Generator({
+  mapUrl: import.meta.url,
+  defaultProvider: 'jspm',
+  env: ['production', 'browser']
+});
+
+await generator.traceInstall('./local/pkg/b.js');
+
+const json = generator.getMap();
+assert.strictEqual(json.scopes['./local/pkg/'].dep, './local/dep/main.js');

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,7 @@
 {
   "compilerOptions": {
     "typeRoots": ["node_modules/@types"],
+    "allowSyntheticDefaultImports": true,
     "moduleResolution": "node",
     "module": "esnext",
     "target": "es2019",


### PR DESCRIPTION
This PR includes the following changes:

* CJS tracing is now supported for local `file:` URLs with Node.js compatible CJS semantics. This means it will be possible to generate import maps for Node.js apps using CJS modules.
* A new `generator.getAnalysis(url)` method for getting the internal analysis from the generator. At the moment this is just `{ staticDeps: string[], dynamicDeps: string[], format: 'commonjs' | 'esm' | 'system' }` but can be extended in future.
* The `getMapInstance` method previously implemented has been moved to just `generator.map` and no longer clones. This makes it easy to call the resolver via `generator.map.resolve('pkg')` or even modify the map via `generator.map.set()` etc per the @jspm/import-map API.
* `generator.traceInstall(specifier, parent)` has been implemented, as it was previously available in former versions of these concepts. This is useful for pointing to the entry points of an application and generating an import map using the package.json dependencies ranges only all done automatically.