### PR TITLE
feat: fixup builtin resolution

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,9 +15,6 @@ jobs:
         firefox: ['89.0']
     steps:
       - uses: actions/checkout@v2
-        with:
-          submodules: true
-      - run: ls jspm-core
       - name: Setup Node.js ${{ matrix.node }}
         uses: actions/setup-node@v2
         with:
@@ -27,7 +24,6 @@ jobs:
         with:
           firefox-version: ${{ matrix.firefox }}
       - run: npm install
-      - run: cd jspm-core && npm install
       - run: npm run build
       - run: npm run test:browser
         env:
@@ -42,11 +38,14 @@ jobs:
         node: [14.x, 16.x]
     steps:
     - uses: actions/checkout@v2
+      with:
+        submodules: true
     - name: Use Node.js ${{ matrix.node }}
       uses: actions/setup-node@v2
       with:
         node: ${{ matrix.node }}
     - run: npm install
+    - run: cd jspm-core && npm install
     - run: npm run build
     - run: npm run test:node
   

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,6 +17,7 @@ jobs:
       - uses: actions/checkout@v2
         with:
           submodules: true
+      - run: ls jspm-core
       - name: Setup Node.js ${{ matrix.node }}
         uses: actions/setup-node@v2
         with:
@@ -26,6 +27,7 @@ jobs:
         with:
           firefox-version: ${{ matrix.firefox }}
       - run: npm install
+      - run: cd jspm-core && npm install
       - run: npm run build
       - run: npm run test:browser
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,6 +15,8 @@ jobs:
         firefox: ['89.0']
     steps:
       - uses: actions/checkout@v2
+        with:
+          submodules: true
       - name: Setup Node.js ${{ matrix.node }}
         uses: actions/setup-node@v2
         with:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jspm/generator",
-  "version": "1.0.0-beta.8",
+  "version": "1.0.0-beta.10",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -272,6 +272,11 @@
         "@babel/helper-validator-identifier": "^7.14.8",
         "to-fast-properties": "^2.0.0"
       }
+    },
+    "@jspm/core": {
+      "version": "2.0.0-beta.7",
+      "resolved": "https://registry.npmjs.org/@jspm/core/-/core-2.0.0-beta.7.tgz",
+      "integrity": "sha512-+nnNWW9UJT41S10ePGdaY2FvJmjgBkpQB6+98FUJEv7Algkj+fNaN1g5feULyF2RTvNDqWLlJWL+ZD3NS5aSzA=="
     },
     "@jspm/import-map": {
       "version": "0.1.5",
@@ -1234,6 +1239,12 @@
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-2.3.0.tgz",
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
+      "dev": true
+    },
+    "process": {
+      "version": "0.11.10",
+      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
+      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
       "dev": true
     },
     "promise-inflight": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1241,12 +1241,6 @@
       "integrity": "sha512-lY1Q/PiJGC2zOv/z391WOTD+Z02bCgsFfvxoXXf6h7kv9o+WmsmzYqrAwY63sNgOxE4xEdq0WyUnXfKeBrSvYw==",
       "dev": true
     },
-    "process": {
-      "version": "0.11.10",
-      "resolved": "https://registry.npmjs.org/process/-/process-0.11.10.tgz",
-      "integrity": "sha1-czIwDoQBYb2j5podHZGn1LwW8YI=",
-      "dev": true
-    },
     "promise-inflight": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/promise-inflight/-/promise-inflight-1.0.1.tgz",

--- a/package.json
+++ b/package.json
@@ -47,7 +47,6 @@
     "lit-element": "^2.5.1",
     "mocha": "^9.0.0",
     "open": "^8.2.0",
-    "process": "^0.11.10",
     "rollup": "^2.44.0",
     "typescript": "^4.3.5"
   },

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.14.8",
+    "@jspm/core": "^2.0.0-beta.7",
     "@jspm/import-map": "^0.1.5",
     "es-module-lexer": "^0.4.1",
     "make-fetch-happen": "^8.0.3",
@@ -46,6 +47,7 @@
     "lit-element": "^2.5.1",
     "mocha": "^9.0.0",
     "open": "^8.2.0",
+    "process": "^0.11.10",
     "rollup": "^2.44.0",
     "typescript": "^4.3.5"
   },

--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -274,7 +274,7 @@ export class Resolver {
       }
     }
     else {
-      if (subpath === '.') {
+      if (subpath === '.' || parentIsCjs && subpath === './') {
         if (env.includes('browser') && typeof pcfg.browser === 'string')
           return this.finalizeResolve(await legacyMainResolve.call(this, pcfg.browser, new URL(pkgUrl), originalSpecifier, pkgUrl), parentIsCjs, env, pkgUrl);
         if (env.includes('module') && typeof pcfg.module === 'string')
@@ -355,7 +355,7 @@ export class Resolver {
       if (imports.every(impt => impt.d > 0) && !exports.length && resolvedUrl.startsWith('file:')) {
         // Support CommonJS package boundary checks for non-ESM on file: protocol only
         if (!(resolvedUrl.endsWith('.js') || resolvedUrl.endsWith('.json') || resolvedUrl.endsWith('.node')) ||
-            resolvedUrl.endsWith('.js') && (await this.getPackageConfig(await this.getPackageBase(resolvedUrl))).type !== 'module') {
+            resolvedUrl.endsWith('.js') && (await this.getPackageConfig(await this.getPackageBase(resolvedUrl)))?.type !== 'module') {
           return createCjsAnalysis(imports, source, resolvedUrl);
         }
       }

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -331,12 +331,6 @@ export default class TraceMap {
     else if (!wasCJS && env.includes('require'))
       env = env.map(e => e === 'require' ? 'import' : e);
 
-    // all real commonjs packages get "process" and "Buffer" dependencies
-    if (format === 'commonjs' && !deps.includes('process') && !deps.includes('process/'))
-      deps.push('process');
-    if (format === 'commonjs' && !deps.includes('buffer') && !deps.includes('buffer/'))
-      deps.push('buffer');
-
     let allDeps: string[] = deps;
     if (dynamicDeps.length && !this.opts.static) {
       allDeps = [...deps];

--- a/test/resolve/builtin-shim.test.js
+++ b/test/resolve/builtin-shim.test.js
@@ -15,21 +15,8 @@ if (typeof document === 'undefined') {
 
   assert.deepStrictEqual(json, {
     scopes: {
-      '../../jspm-core/node_modules/buffer/': {
-        buffer: '../../jspm-core/nodelibs/buffer.js',
-        process: '../../jspm-core/nodelibs/process.js'
-      },
-      '../../jspm-core/node_modules/process/': {
-        buffer: '../../jspm-core/nodelibs/buffer.js',
-        process: '../../jspm-core/nodelibs/process.js'
-      },
       './cjspkg/': {
         'process/': './cjspkg/node_modules/process/index.js',
-        buffer: '../../jspm-core/nodelibs/buffer.js'
-      },
-      './cjspkg/node_modules/process/': {
-        buffer: '../../jspm-core/nodelibs/buffer.js',
-        process: '../../jspm-core/nodelibs/process.js'
       }
     }
   });

--- a/test/resolve/builtin-shim.test.js
+++ b/test/resolve/builtin-shim.test.js
@@ -1,0 +1,35 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+if (typeof document === 'undefined' && false) {
+  const generator = new Generator({
+    stdlib: new URL('../../jspm-core/', import.meta.url),
+    mapUrl: import.meta.url,
+    defaultProvider: 'nodemodules'
+  });
+
+  // await generator.traceInstall('./cjspkg/mod.js');
+  await generator.traceInstall('./cjspkg/mod-shim.js');
+
+  const json = generator.getMap();
+
+  console.log(json);
+
+  assert.deepStrictEqual(json, {
+    imports: {
+      '../../node_modules/chalk/source/templates': '../../node_modules/chalk/source/templates.js',
+      '../../node_modules/chalk/source/util': '../../node_modules/chalk/source/util.js',
+      '../../node_modules/color-convert/conversions': '../../node_modules/color-convert/conversions.js',        
+      '../../node_modules/color-convert/route': '../../node_modules/color-convert/route.js',
+      chalk: '../../node_modules/chalk/source/index.js'
+    },
+    scopes: {
+      '../../node_modules/ansi-styles/': { 'color-convert': '../../node_modules/color-convert/index.js' },      
+      '../../node_modules/chalk/': {
+        'ansi-styles': '../../node_modules/ansi-styles/index.js',
+        'supports-color': '../../node_modules/supports-color/browser.js'
+      },
+      '../../node_modules/color-convert/': { 'color-name': '../../node_modules/color-name/index.js' }
+    }
+  });
+}

--- a/test/resolve/builtin-shim.test.js
+++ b/test/resolve/builtin-shim.test.js
@@ -1,7 +1,7 @@
 import { Generator } from '@jspm/generator';
 import assert from 'assert';
 
-if (typeof document === 'undefined' && false) {
+if (typeof document === 'undefined') {
   const generator = new Generator({
     stdlib: new URL('../../jspm-core/', import.meta.url),
     mapUrl: import.meta.url,
@@ -13,23 +13,24 @@ if (typeof document === 'undefined' && false) {
 
   const json = generator.getMap();
 
-  console.log(json);
-
   assert.deepStrictEqual(json, {
-    imports: {
-      '../../node_modules/chalk/source/templates': '../../node_modules/chalk/source/templates.js',
-      '../../node_modules/chalk/source/util': '../../node_modules/chalk/source/util.js',
-      '../../node_modules/color-convert/conversions': '../../node_modules/color-convert/conversions.js',        
-      '../../node_modules/color-convert/route': '../../node_modules/color-convert/route.js',
-      chalk: '../../node_modules/chalk/source/index.js'
-    },
     scopes: {
-      '../../node_modules/ansi-styles/': { 'color-convert': '../../node_modules/color-convert/index.js' },      
-      '../../node_modules/chalk/': {
-        'ansi-styles': '../../node_modules/ansi-styles/index.js',
-        'supports-color': '../../node_modules/supports-color/browser.js'
+      '../../jspm-core/node_modules/buffer/': {
+        buffer: '../../jspm-core/nodelibs/buffer.js',
+        process: '../../jspm-core/nodelibs/process.js'
       },
-      '../../node_modules/color-convert/': { 'color-name': '../../node_modules/color-name/index.js' }
+      '../../jspm-core/node_modules/process/': {
+        buffer: '../../jspm-core/nodelibs/buffer.js',
+        process: '../../jspm-core/nodelibs/process.js'
+      },
+      './cjspkg/': {
+        'process/': './cjspkg/node_modules/process/index.js',
+        buffer: '../../jspm-core/nodelibs/buffer.js'
+      },
+      './cjspkg/node_modules/process/': {
+        buffer: '../../jspm-core/nodelibs/buffer.js',
+        process: '../../jspm-core/nodelibs/process.js'
+      }
     }
   });
 }

--- a/test/resolve/chalk.test.js
+++ b/test/resolve/chalk.test.js
@@ -20,12 +20,30 @@ if (typeof document === 'undefined') {
       chalk: '../../node_modules/chalk/source/index.js'
     },
     scopes: {
-      '../../node_modules/ansi-styles/': { 'color-convert': '../../node_modules/color-convert/index.js' },      
+      '../../node_modules/ansi-styles/': {
+        buffer: '../../node_modules/@jspm/core/nodelibs/buffer.js',
+        'color-convert': '../../node_modules/color-convert/index.js',
+        process: '../../node_modules/@jspm/core/nodelibs/process.js'
+      },
       '../../node_modules/chalk/': {
         'ansi-styles': '../../node_modules/ansi-styles/index.js',
+        buffer: '../../node_modules/@jspm/core/nodelibs/buffer.js',
+        process: '../../node_modules/@jspm/core/nodelibs/process.js',
         'supports-color': '../../node_modules/supports-color/browser.js'
       },
-      '../../node_modules/color-convert/': { 'color-name': '../../node_modules/color-name/index.js' }
+      '../../node_modules/color-convert/': {
+        buffer: '../../node_modules/@jspm/core/nodelibs/buffer.js',
+        'color-name': '../../node_modules/color-name/index.js',
+        process: '../../node_modules/@jspm/core/nodelibs/process.js'
+      },
+      '../../node_modules/color-name/': {
+        buffer: '../../node_modules/@jspm/core/nodelibs/buffer.js',
+        process: '../../node_modules/@jspm/core/nodelibs/process.js'
+      },
+      '../../node_modules/supports-color/': {
+        buffer: '../../node_modules/@jspm/core/nodelibs/buffer.js',
+        process: '../../node_modules/@jspm/core/nodelibs/process.js'
+      }
     }
   });
 }

--- a/test/resolve/chalk.test.js
+++ b/test/resolve/chalk.test.js
@@ -21,28 +21,14 @@ if (typeof document === 'undefined') {
     },
     scopes: {
       '../../node_modules/ansi-styles/': {
-        buffer: '../../node_modules/@jspm/core/nodelibs/buffer.js',
-        'color-convert': '../../node_modules/color-convert/index.js',
-        process: '../../node_modules/@jspm/core/nodelibs/process.js'
+        'color-convert': '../../node_modules/color-convert/index.js'
       },
       '../../node_modules/chalk/': {
         'ansi-styles': '../../node_modules/ansi-styles/index.js',
-        buffer: '../../node_modules/@jspm/core/nodelibs/buffer.js',
-        process: '../../node_modules/@jspm/core/nodelibs/process.js',
         'supports-color': '../../node_modules/supports-color/browser.js'
       },
       '../../node_modules/color-convert/': {
-        buffer: '../../node_modules/@jspm/core/nodelibs/buffer.js',
-        'color-name': '../../node_modules/color-name/index.js',
-        process: '../../node_modules/@jspm/core/nodelibs/process.js'
-      },
-      '../../node_modules/color-name/': {
-        buffer: '../../node_modules/@jspm/core/nodelibs/buffer.js',
-        process: '../../node_modules/@jspm/core/nodelibs/process.js'
-      },
-      '../../node_modules/supports-color/': {
-        buffer: '../../node_modules/@jspm/core/nodelibs/buffer.js',
-        process: '../../node_modules/@jspm/core/nodelibs/process.js'
+        'color-name': '../../node_modules/color-name/index.js'
       }
     }
   });

--- a/test/resolve/cjspkg/mod-shim.js
+++ b/test/resolve/cjspkg/mod-shim.js
@@ -1,0 +1,4 @@
+const depProcess = require('process/');
+
+console.log(depProcess === 'process shim');
+

--- a/test/resolve/cjspkg/mod.js
+++ b/test/resolve/cjspkg/mod.js
@@ -1,0 +1,4 @@
+const builtinProcess = require('process');
+
+console.log(builtinProcess === process);
+

--- a/test/resolve/cjspkg/node_modules/process/index.js
+++ b/test/resolve/cjspkg/node_modules/process/index.js
@@ -1,0 +1,1 @@
+module.exports = 'process shim';

--- a/test/resolve/cjspkg/package.json
+++ b/test/resolve/cjspkg/package.json
@@ -1,0 +1,5 @@
+{
+  "dependencies": {
+    "process": "^0.11.10"
+  }
+}


### PR DESCRIPTION
This fixes up builtin resolution, ensuring Node.js builtins are given precedence over normal dependencies resolutions to match the Node.js specification and also supporting builtin resolution for the nodemodules resolver.

Finally an exception is made for the `require('assert/')` pattern that is used to specially allow requiring npm:assert instead of getting the builtin which is an old Browserify trick. Supported here only for CJS to avoid polluting esm semantics just as in the Node.js ESM resolver itself.