### PR TITLE
feat: support typescript format

### DIFF
--- a/src/generator.d.ts
+++ b/src/generator.d.ts
@@ -1,5 +1,4 @@
 import { ImportMap } from '@jspm/import-map';
-import { NonRelativeModuleNameResolutionCache } from 'typescript';
 
 export type LogStream = () => AsyncGenerator<{ type: string, message: string }, never, unknown>;
 
@@ -46,7 +45,7 @@ export declare class Generator {
 }
 
 export interface ModuleAnalysis {
-  format: 'commonjs' | 'esm' | 'system';
+  format: 'commonjs' | 'esm' | 'system' | 'json' | 'typescript';
   staticDeps: string[];
   dynamicDeps: string[];
   cjsLazyDeps: string[] | null;

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -25,7 +25,7 @@ export interface GeneratorOptions {
 }
 
 export interface ModuleAnalysis {
-  format: 'commonjs' | 'esm' | 'system' | 'json';
+  format: 'commonjs' | 'esm' | 'system' | 'json' | 'typescript';
   staticDeps: string[];
   dynamicDeps: string[];
   cjsLazyDeps: string[] | null;

--- a/src/trace/analysis.ts
+++ b/src/trace/analysis.ts
@@ -2,7 +2,7 @@ export interface Analysis {
   deps: string[];
   dynamicDeps: string[];
   cjsLazyDeps: string[] | null;
-  format: 'esm' | 'commonjs' | 'system' | 'json';
+  format: 'esm' | 'commonjs' | 'system' | 'json' | 'typescript';
   size: number;
 }
 

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -40,7 +40,7 @@ interface TraceEntry {
   // For cjs modules, the list of hoisted deps
   // this is needed for proper cycle handling
   cjsLazyDeps: Record<string, string | string[]>;
-  format: 'esm' | 'commonjs' | 'system' | 'json';
+  format: 'esm' | 'commonjs' | 'system' | 'json' | 'typescript';
 }
 
 // The tracemap fully drives the installer

--- a/test/resolve/ts.test.js
+++ b/test/resolve/ts.test.js
@@ -1,0 +1,13 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+if (typeof document === 'undefined') {
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: 'nodemodules'
+  });
+
+  await generator.traceInstall('./tspkg/main.ts');
+
+  assert.strictEqual(generator.getAnalysis(new URL('./tspkg/dep.ts', import.meta.url)).format, 'typescript');
+}

--- a/test/resolve/tspkg/dep.ts
+++ b/test/resolve/tspkg/dep.ts
@@ -1,0 +1,1 @@
+export var dep: string = 'dep';

--- a/test/resolve/tspkg/main.ts
+++ b/test/resolve/tspkg/main.ts
@@ -1,0 +1,2 @@
+import './dep.ts';
+export var p: number = 5;


### PR DESCRIPTION
This supports `format: 'typescript'` as a traced format in the analysis function, useful for determining if typescript is traced and which files are typescript.