### PR TITLE
feat: apply realpath for file: URLs in traces

### DIFF
--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -190,11 +190,11 @@ export class Resolver {
       return url;
     if (!realpath) {
       [{ realpath }, { pathToFileURL }] = await Promise.all([
-        import('fs/promises' as any),
+        import('fs' as any),
         import('url' as any)
       ]);
     }
-    return pathToFileURL(await realpath(new URL(url))).href;
+    return pathToFileURL(await new Promise((resolve, reject) => realpath(new URL(url), (err, result) => err ? reject(err) : resolve(result)))).href;
   }
 
   async finalizeResolve (url: string, parentIsCjs: boolean, env: string[], pkgUrl?: string): Promise<string> {

--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -9,17 +9,21 @@ import { getProvider, defaultProviders, Provider } from '../providers/index.js';
 import { Analysis, createSystemAnalysis, parseTs } from './analysis.js';
 import { createEsmAnalysis } from './analysis.js';
 import { createCjsAnalysis } from './cjs.js';
-import { getMapMatch, resolveConditional } from '@jspm/import-map';
+import { getMapMatch } from '@jspm/import-map';
+
+let realpath, pathToFileURL;
 
 export class Resolver {
   log: Log;
   pcfgPromises: Record<string, Promise<void>> = Object.create(null);
   pcfgs: Record<string, PackageConfig | null> = Object.create(null);
   fetchOpts: any;
+  preserveSymlinks = false;
   providers = defaultProviders;
-  constructor (log: Log, fetchOpts?: any) {
+  constructor (log: Log, fetchOpts?: any, preserveSymlinks = false) {
     this.log = log;
     this.fetchOpts = fetchOpts;
+    this.preserveSymlinks = preserveSymlinks;
   }
 
   addCustomProvider (name: string, provider: Provider) {
@@ -179,6 +183,18 @@ export class Resolver {
       return false;
     const subpath = './' + url.slice(pkgUrl.length);
     return pcfg?.exports?.[subpath + '!cjs'] ? true : false;
+  }
+
+  async realPath (url: string): Promise<string> {
+    if (!url.startsWith('file:') || this.preserveSymlinks)
+      return url;
+    if (!realpath) {
+      [{ realpath }, { pathToFileURL }] = await Promise.all([
+        import('fs/promises' as any),
+        import('url' as any)
+      ]);
+    }
+    return pathToFileURL(await realpath(new URL(url))).href;
   }
 
   async finalizeResolve (url: string, parentIsCjs: boolean, env: string[], pkgUrl?: string): Promise<string> {

--- a/test/api/self.test.js
+++ b/test/api/self.test.js
@@ -7,7 +7,7 @@ const generator = new Generator({
 
 const { staticDeps, dynamicDeps } = await generator.install('@jspm/generator');
 
-assert.strictEqual(staticDeps.length, 10);
+assert.strictEqual(staticDeps.length, 14);
 assert.strictEqual(dynamicDeps.length, 0);
 
 const json = generator.getMap();


### PR DESCRIPTION
This will add mappings into the generated import map for all symlinked resolutions to point to their actual path.

This will ensure symlinked paths only have a singular identity which will fix Node.js edge cases with symlinked node_modules etc. Because these are import map mappings, it would 100% support Deno too anyway.

There is also a `preserveSymlinks` resolver option that can be used to disable this feature if that turns out useful, but it is not currently exposed in the final generator options.