### PR TITLE
fix: make typescript prod dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1452,7 +1452,7 @@
       "version": "4.3.5",
       "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.3.5.tgz",
       "integrity": "sha512-DqQgihaQ9cUrskJo9kIyW/+g0Vxsk8cDtZ52a3NGh0YNTfpUSArXSohyUGnvbPazEPLu398C0UxmKSOrPumUzA==",
-      "dev": true
+      "dev": false
     },
     "unique-filename": {
       "version": "1.1.1",

--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
     "@jspm/import-map": "^0.1.5",
     "es-module-lexer": "^0.4.1",
     "make-fetch-happen": "^8.0.3",
-    "sver": "^1.8.3"
+    "sver": "^1.8.3",
+    "typescript": "^4.3.5"
   },
   "devDependencies": {
     "chalk": "^4.1.1",
@@ -50,8 +51,7 @@
     "lit-element": "^2.5.1",
     "mocha": "^9.0.0",
     "open": "^8.2.0",
-    "rollup": "^2.44.0",
-    "typescript": "^4.3.5"
+    "rollup": "^2.44.0"
   },
   "files": [
     "dist"


### PR DESCRIPTION
`typescript` can be used here: https://github.com/jspm/generator/blob/765852b7edf7c7763de54c609922bd06a28860f0/src/trace/analysis.ts#L13.
