### PR TITLE
feat: @babel/core Deno support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@jspm/generator",
-  "version": "1.0.0-beta.10",
+  "version": "1.0.0-beta.11",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
@@ -49,6 +49,14 @@
         "source-map": "^0.5.0"
       }
     },
+    "@babel/helper-annotate-as-pure": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-annotate-as-pure/-/helper-annotate-as-pure-7.14.5.tgz",
+      "integrity": "sha512-EivH9EgBIb+G8ij1B2jAwSH36WnGvkQSEC6CkX/6v6ZFlw5fVOHvsgGF4uiEHO2GzMvunZb6tDLQEQSdrdocrA==",
+      "requires": {
+        "@babel/types": "^7.14.5"
+      }
+    },
     "@babel/helper-compilation-targets": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/helper-compilation-targets/-/helper-compilation-targets-7.14.5.tgz",
@@ -58,6 +66,85 @@
         "@babel/helper-validator-option": "^7.14.5",
         "browserslist": "^4.16.6",
         "semver": "^6.3.0"
+      }
+    },
+    "@babel/helper-create-class-features-plugin": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/helper-create-class-features-plugin/-/helper-create-class-features-plugin-7.15.0.tgz",
+      "integrity": "sha512-MdmDXgvTIi4heDVX/e9EFfeGpugqm9fobBVg/iioE8kueXrOHdRDe36FAY7SnE9xXLVeYCoJR/gdrBEIHRC83Q==",
+      "requires": {
+        "@babel/helper-annotate-as-pure": "^7.14.5",
+        "@babel/helper-function-name": "^7.14.5",
+        "@babel/helper-member-expression-to-functions": "^7.15.0",
+        "@babel/helper-optimise-call-expression": "^7.14.5",
+        "@babel/helper-replace-supers": "^7.15.0",
+        "@babel/helper-split-export-declaration": "^7.14.5"
+      },
+      "dependencies": {
+        "@babel/generator": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/generator/-/generator-7.15.0.tgz",
+          "integrity": "sha512-eKl4XdMrbpYvuB505KTta4AV9g+wWzmVBW69tX0H2NwKVKd2YJbKgyK6M8j/rgLbmHOYJn6rUklV677nOyJrEQ==",
+          "requires": {
+            "@babel/types": "^7.15.0",
+            "jsesc": "^2.5.1",
+            "source-map": "^0.5.0"
+          }
+        },
+        "@babel/helper-member-expression-to-functions": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-member-expression-to-functions/-/helper-member-expression-to-functions-7.15.0.tgz",
+          "integrity": "sha512-Jq8H8U2kYiafuj2xMTPQwkTBnEEdGKpT35lJEQsRRjnG0LW3neucsaMWLgKcwu3OHKNeYugfw+Z20BXBSEs2Lg==",
+          "requires": {
+            "@babel/types": "^7.15.0"
+          }
+        },
+        "@babel/helper-replace-supers": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/helper-replace-supers/-/helper-replace-supers-7.15.0.tgz",
+          "integrity": "sha512-6O+eWrhx+HEra/uJnifCwhwMd6Bp5+ZfZeJwbqUTuqkhIT6YcRhiZCOOFChRypOIe0cV46kFrRBlm+t5vHCEaA==",
+          "requires": {
+            "@babel/helper-member-expression-to-functions": "^7.15.0",
+            "@babel/helper-optimise-call-expression": "^7.14.5",
+            "@babel/traverse": "^7.15.0",
+            "@babel/types": "^7.15.0"
+          }
+        },
+        "@babel/helper-validator-identifier": {
+          "version": "7.14.9",
+          "resolved": "https://registry.npmjs.org/@babel/helper-validator-identifier/-/helper-validator-identifier-7.14.9.tgz",
+          "integrity": "sha512-pQYxPY0UP6IHISRitNe8bsijHex4TWZXi2HwKVsjPiltzlhse2znVcm9Ace510VT1kxIHjGJCZZQBX2gJDbo0g=="
+        },
+        "@babel/parser": {
+          "version": "7.15.3",
+          "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.15.3.tgz",
+          "integrity": "sha512-O0L6v/HvqbdJawj0iBEfVQMc3/6WP+AeOsovsIgBFyJaG+W2w7eqvZB7puddATmWuARlm1SX7DwxJ/JJUnDpEA=="
+        },
+        "@babel/traverse": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/traverse/-/traverse-7.15.0.tgz",
+          "integrity": "sha512-392d8BN0C9eVxVWd8H6x9WfipgVH5IaIoLp23334Sc1vbKKWINnvwRpb4us0xtPaCumlwbTtIYNA0Dv/32sVFw==",
+          "requires": {
+            "@babel/code-frame": "^7.14.5",
+            "@babel/generator": "^7.15.0",
+            "@babel/helper-function-name": "^7.14.5",
+            "@babel/helper-hoist-variables": "^7.14.5",
+            "@babel/helper-split-export-declaration": "^7.14.5",
+            "@babel/parser": "^7.15.0",
+            "@babel/types": "^7.15.0",
+            "debug": "^4.1.0",
+            "globals": "^11.1.0"
+          }
+        },
+        "@babel/types": {
+          "version": "7.15.0",
+          "resolved": "https://registry.npmjs.org/@babel/types/-/types-7.15.0.tgz",
+          "integrity": "sha512-OBvfqnllOIdX4ojTHpwZbpvz4j3EWyjkZEdmjH0/cgsd6QOdSgU8rLSk6ard/pcW7rlmjdVSX/AWOaORR1uNOQ==",
+          "requires": {
+            "@babel/helper-validator-identifier": "^7.14.9",
+            "to-fast-properties": "^2.0.0"
+          }
+        }
       }
     },
     "@babel/helper-function-name": {
@@ -124,6 +211,11 @@
       "requires": {
         "@babel/types": "^7.14.5"
       }
+    },
+    "@babel/helper-plugin-utils": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/helper-plugin-utils/-/helper-plugin-utils-7.14.5.tgz",
+      "integrity": "sha512-/37qQCE3K0vvZKwoK4XU/irIJQdIfCJuhU5eKnNxpFDsOkgFaUAwbv+RYw6eYgsC0E4hS7r5KqGULUogqui0fQ=="
     },
     "@babel/helper-replace-supers": {
       "version": "7.14.5",
@@ -238,6 +330,34 @@
       "resolved": "https://registry.npmjs.org/@babel/parser/-/parser-7.14.8.tgz",
       "integrity": "sha512-syoCQFOoo/fzkWDeM0dLEZi5xqurb5vuyzwIMNZRNun+N/9A4cUZeQaE7dTrB8jGaKuJRBtEOajtnmw0I5hvvA=="
     },
+    "@babel/plugin-syntax-typescript": {
+      "version": "7.14.5",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-typescript/-/plugin-syntax-typescript-7.14.5.tgz",
+      "integrity": "sha512-u6OXzDaIXjEstBRRoBCQ/uKQKlbuaeE5in0RvWdA4pN6AhqxTIwUsnHPU1CFZA/amYObMsuWhYfRl3Ch90HD0Q==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5"
+      }
+    },
+    "@babel/plugin-transform-typescript": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/plugin-transform-typescript/-/plugin-transform-typescript-7.15.0.tgz",
+      "integrity": "sha512-WIIEazmngMEEHDaPTx0IZY48SaAmjVWe3TRSX7cmJXn0bEv9midFzAjxiruOWYIVf5iQ10vFx7ASDpgEO08L5w==",
+      "requires": {
+        "@babel/helper-create-class-features-plugin": "^7.15.0",
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/plugin-syntax-typescript": "^7.14.5"
+      }
+    },
+    "@babel/preset-typescript": {
+      "version": "7.15.0",
+      "resolved": "https://registry.npmjs.org/@babel/preset-typescript/-/preset-typescript-7.15.0.tgz",
+      "integrity": "sha512-lt0Y/8V3y06Wq/8H/u0WakrqciZ7Fz7mwPDHWUJAXlABL5hiUG42BNlRXiELNjeWjO5rWmnNKlx+yzJvxezHow==",
+      "requires": {
+        "@babel/helper-plugin-utils": "^7.14.5",
+        "@babel/helper-validator-option": "^7.14.5",
+        "@babel/plugin-transform-typescript": "^7.15.0"
+      }
+    },
     "@babel/template": {
       "version": "7.14.5",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.14.5.tgz",
@@ -274,9 +394,9 @@
       }
     },
     "@jspm/core": {
-      "version": "2.0.0-beta.7",
-      "resolved": "https://registry.npmjs.org/@jspm/core/-/core-2.0.0-beta.7.tgz",
-      "integrity": "sha512-+nnNWW9UJT41S10ePGdaY2FvJmjgBkpQB6+98FUJEv7Algkj+fNaN1g5feULyF2RTvNDqWLlJWL+ZD3NS5aSzA=="
+      "version": "2.0.0-beta.8",
+      "resolved": "https://registry.npmjs.org/@jspm/core/-/core-2.0.0-beta.8.tgz",
+      "integrity": "sha512-xul0U82Hg0nsTUTrBhJ35J1IBzCKBKv1JSaDMtJGqYi/x+Q7HqpwXZ5is5Vfd7HW60ARBAQETa29UUbpuF0jbA=="
     },
     "@jspm/import-map": {
       "version": "0.1.5",

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
   },
   "dependencies": {
     "@babel/core": "^7.14.8",
+    "@babel/preset-typescript": "^7.15.0",
     "@jspm/core": "^2.0.0-beta.8",
     "@jspm/import-map": "^0.1.5",
     "es-module-lexer": "^0.4.1",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "default": "./dist/generator.js"
   },
   "dependencies": {
-    "@babel/core": "^7.14.8",
+    "@babel/core": "^7.15.0",
     "@babel/preset-typescript": "^7.15.0",
     "@jspm/core": "^2.0.0-beta.8",
     "@jspm/import-map": "^0.1.5",

--- a/src/common/fetch-deno.ts
+++ b/src/common/fetch-deno.ts
@@ -3,7 +3,8 @@ import { fetch as _fetch } from './fetch-native.js';
 // @ts-ignore
 import { fileURLToPath } from 'url';
 // @ts-ignore
-import { cache } from "https://deno.land/x/cache/mod.ts";
+// Caching disabled due to not respecting cache headers...
+// import { cache } from "https://deno.land/x/cache/mod.ts";
 
 export function clearCache () {
 };
@@ -56,34 +57,35 @@ export const fetch = async function (url: URL, ...args: any[]) {
     }
   }
   else {
-    let file;
-    try {
-      file = await cache(urlString);
-    }
-    catch (e) {
-      if (e.name === 'SyntaxError') {
-        // Weird bug in Deno cache...
-        // @ts-ignore
-        return _fetch(url, ...args);
-      }
-      if (e.name === 'CacheError' && e.message === 'Not Found') {
-        return { status: 404, statusText: e.toString() };
-      }
-      throw e;
-    }
+    return _fetch(urlString, ...args);
+    // let file;
+    // try {
+    //   file = await cache(urlString);
+    // }
+    // catch (e) {
+    //   if (e.name === 'SyntaxError') {
+    //     // Weird bug in Deno cache...
+    //     // @ts-ignore
+    //     return _fetch(url, ...args);
+    //   }
+    //   if (e.name === 'CacheError' && e.message === 'Not Found') {
+    //     return { status: 404, statusText: e.toString() };
+    //   }
+    //   throw e;
+    // }
     // @ts-ignore
-    const source = await Deno.readTextFile(file.path);
-    return {
-      status: 200,
-      async text () {
-        return source.toString();
-      },
-      async json () {
-        return JSON.parse(source.toString());
-      },
-      arrayBuffer () {
-        return source;
-      }
-    };
+    // const source = await Deno.readTextFile(fromFileUrl(urlString));
+    // return {
+    //   status: 200,
+    //   async text () {
+    //     return source.toString();
+    //   },
+    //   async json () {
+    //     return JSON.parse(source.toString());
+    //   },
+    //   arrayBuffer () {
+    //     return source;
+    //   }
+    // };
   }
 }

--- a/src/trace/analysis.ts
+++ b/src/trace/analysis.ts
@@ -6,18 +6,8 @@ export interface Analysis {
   size: number;
 }
 
-export async function parseTs (source: string) {
-  // @ts-ignore
-  if (typeof Deno !== 'undefined')
-    return '';
-  const { default: ts } = await import(eval('"typescript"'));
-  return ts.transpileModule(source, {
-    compilerOptions: {
-      jsx: ts.JsxEmit.React,
-      module: ts.ModuleKind.ESNext
-    }
-  }).outputText;
-}
+export { createTsAnalysis } from './ts.js';
+export { createCjsAnalysis } from './cjs.js';
 
 export function createEsmAnalysis (imports: any[], source: string, url: string): Analysis {
   if (!imports.length && registerRegEx.test(source))

--- a/src/trace/cjs.ts
+++ b/src/trace/cjs.ts
@@ -1,13 +1,16 @@
 import { Analysis } from "./analysis";
 
+let babel;
+
 export async function createCjsAnalysis (imports: any, source: string, url: string): Promise<Analysis> {
-  const { default: babel } = await import(eval('"@babel/core"'));
+  if (!babel)
+    ({ default: babel } = await import('@babel/core'));
 
   const requires = new Set<string>();
   const lazy = new Set<string>();
 
-  const { ast: _ast } = babel.transform(source, {
-    ast: true,
+  babel.transform(source, {
+    ast: false,
     sourceMaps: false,
     inputSourceMap: false,
     babelrc: false,

--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -6,9 +6,7 @@ import { fetch } from '#fetch';
 import { importedFrom } from "../common/url.js";
 import { parse } from 'es-module-lexer';
 import { getProvider, defaultProviders, Provider } from '../providers/index.js';
-import { Analysis, createSystemAnalysis, parseTs } from './analysis.js';
-import { createEsmAnalysis } from './analysis.js';
-import { createCjsAnalysis } from './cjs.js';
+import { Analysis, createSystemAnalysis, createCjsAnalysis, createEsmAnalysis, createTsAnalysis } from './analysis.js';
 import { getMapMatch } from '@jspm/import-map';
 
 let realpath, pathToFileURL;
@@ -366,15 +364,10 @@ export class Resolver {
     let source = await res.text();
     // TODO: headers over extensions for non-file URLs
     try {
-      if (resolvedUrl.endsWith('.ts') || resolvedUrl.endsWith('.tsx') || resolvedUrl.endsWith('.jsx')) {
-        source = await parseTs(source);
-        const [imports] = await parse(source) as any as [any[], string[]];
-        const esmAnalysis = createEsmAnalysis(imports, source, resolvedUrl);
-        esmAnalysis.format = 'typescript';
-        return esmAnalysis;
+      if (resolvedUrl.endsWith('.ts') || resolvedUrl.endsWith('.tsx') || resolvedUrl.endsWith('.jsx'))
+        return await createTsAnalysis(source, resolvedUrl);
 
-      }
-      else if (resolvedUrl.endsWith('.json')) {
+      if (resolvedUrl.endsWith('.json')) {
         try {
           JSON.parse(source);
           return { deps: [], dynamicDeps: [], cjsLazyDeps: null, size: source.length, format: 'json' };

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -276,10 +276,10 @@ export default class TraceMap {
 
     // Imports
     if (pcfg.imports && pkgName[0] === '#') {
-      const match = getMapMatch(pkgName, pcfg.imports);
+      const match = getMapMatch(specifier, pcfg.imports);
       if (!match)
-        throw new JspmError(`No '${pkgName}' import defined in ${parentPkgUrl}${importedFrom(parentUrl)}.`);
-      const resolved = await this.resolver.realPath(resolvePackageTarget(pcfg.imports[match], parentPkgUrl, env, subpath === '.' ? '' : subpath.slice(2)));
+        throw new JspmError(`No '${specifier}' import defined in ${parentPkgUrl}${importedFrom(parentUrl)}.`);
+      const resolved = await this.resolver.realPath(resolvePackageTarget(pcfg.imports[match], parentPkgUrl, env, specifier.slice(match.length)));
       setResolution(this.installer.installs, pkgName, parentPkgUrl, resolved);
       this.log('trace', `${specifier} ${parentUrl.href} -> ${resolved}`);
       await this.traceUrl(resolved, parentUrl, env);

--- a/src/trace/ts.ts
+++ b/src/trace/ts.ts
@@ -1,0 +1,130 @@
+import { Analysis } from "./analysis";
+
+let babel, babelPresetTs;
+
+const globalConsole = globalThis.console;
+const dummyConsole = {
+  log () {}, warn () {}, memory () {}, assert() {}, clear() {}, count() {}, countReset() {}, debug () {},
+  dir () {}, dirxml () {}, error () {}, exception () {}, group () {}, groupCollapsed () {}, groupEnd () {},
+  info () {}, table () {}, time () {}, timeEnd () {}, timeLog () {}, timeStamp () {}, trace () {}
+};
+
+export async function createTsAnalysis (source: string, url: string): Promise<Analysis> {
+  if (!babel)
+    [{ default: babel }, { default: { default: babelPresetTs } }] = await Promise.all([
+      import('@babel/core'),
+      import('@babel/preset-typescript')
+    ]);
+
+  const imports = new Set<string>();
+  const dynamicImports = new Set<string>();
+  let importMeta = false;
+
+  globalThis.console = dummyConsole;
+  try {
+    babel.transform(source, {
+      filename: url.slice(url.lastIndexOf('/') + 1),
+      ast: false,
+      sourceMaps: false,
+      inputSourceMap: false,
+      babelrc: false,
+      babelrcRoots: false,
+      configFile: false,
+      highlightCode: false,
+      compact: false,
+      sourceType: 'module',
+      parserOpts: {
+        // plugins: stage3Syntax,
+        errorRecovery: true
+      },
+      presets: [[babelPresetTs, {
+        onlyRemoveTypeImports: true
+      }]],
+      plugins: [({ types: t }) => {
+        return {
+          visitor: {
+            ExportAllDeclaration (path) {
+              imports.add(path.node.source.value);
+            },
+            ExportNamedDeclaration (path) {
+              if (path.node.source)
+                imports.add(path.node.source.value);
+            },
+            ImportDeclaration (path) {
+              imports.add(path.node.source.value);
+            },
+            Import (path) {
+              dynamicImports.add(buildDynamicString(path.parentPath.get('arguments.0').node, url, true));
+            },
+            MetaProperty (path) {
+              if (t.isIdentifier(path.node.meta, { name: 'import' }) &&
+                  t.isIdentifier(path.node.property, { name: 'meta' })) {
+                importMeta = true;
+              }
+            }
+          }
+        };
+      }]
+    });
+  }
+  finally {
+    globalThis.console = globalConsole;
+  }
+
+  return {
+    deps: [...imports],
+    dynamicDeps: [...dynamicImports],
+    cjsLazyDeps: null,
+    size: source.length,
+    format: 'typescript'
+  };
+}
+
+function buildDynamicString (node, fileName, isEsm = false, lastIsWildcard = false): string {
+  if (node.type === 'StringLiteral') {
+    return node.value;
+  }
+  if (node.type === 'TemplateLiteral') {
+    let str = '';
+    for (let i = 0; i < node.quasis.length; i++) {
+      const quasiStr = node.quasis[i].value.cooked;
+      if (quasiStr.length) {
+        str += quasiStr;
+        lastIsWildcard = false;
+      }
+      const nextNode = node.expressions[i];
+      if (nextNode) {
+        const nextStr = buildDynamicString(nextNode, fileName, isEsm, lastIsWildcard);
+        if (nextStr.length) {
+          lastIsWildcard = nextStr.endsWith('*');
+          str += nextStr;
+        }
+      }
+    }
+    return str;
+  }
+  if (node.type === 'BinaryExpression' && node.operator === '+') {
+    const leftResolved = buildDynamicString(node.left, fileName, isEsm, lastIsWildcard);
+    if (leftResolved.length)
+      lastIsWildcard = leftResolved.endsWith('*');
+    const rightResolved = buildDynamicString(node.right, fileName, isEsm, lastIsWildcard);
+    return leftResolved + rightResolved;
+  }
+  if (isEsm && node.type === 'Identifier') {
+    if (node.name === '__dirname')
+      return '.';
+    if (node.name === '__filename')
+      return './' + fileName;
+  }
+  // TODO: proper expression support
+  // new URL('...', import.meta.url).href | new URL('...', import.meta.url).toString() | new URL('...', import.meta.url).pathname
+  // import.meta.X
+  /*if (isEsm && node.type === 'MemberExpression' && node.object.type === 'MetaProperty' &&
+      node.object.meta.type === 'Identifier' && node.object.meta.name === 'import' &&
+      node.object.property.type === 'Identifier' && node.object.property.name === 'meta') {
+    if (node.property.type === 'Identifier' && node.property.name === 'url') {
+      return './' + fileName;
+    }
+  }*/
+  return lastIsWildcard ? '' : '*';
+}

--- a/test/api/self.test.js
+++ b/test/api/self.test.js
@@ -7,7 +7,7 @@ const generator = new Generator({
 
 const { staticDeps, dynamicDeps } = await generator.install('@jspm/generator');
 
-assert.strictEqual(staticDeps.length, 17);
+assert.strictEqual(staticDeps.length, 106);
 assert.strictEqual(dynamicDeps.length, 0);
 
 const json = generator.getMap();

--- a/test/deno.js
+++ b/test/deno.js
@@ -15,5 +15,5 @@ export function denoExec (map, source) {
   const tmpSrc = resolve(tmpDir, 'app.js');
   writeFileSync(tmpMap, JSON.stringify(map));
   writeFileSync(tmpSrc, source);
-  execSync(`${process.env.DENO_BIN || 'deno'} run --unstable --no-check --allow-all --import-map=${tmpMap} ${tmpSrc}`);
+  execSync(`${process.env.DENO_BIN || 'deno'} run --reload --unstable --no-check --allow-all --import-map=${tmpMap} ${tmpSrc}`, { stdio: 'inherit' });
 }

--- a/test/deno/babel.test.js
+++ b/test/deno/babel.test.js
@@ -1,18 +1,19 @@
-import { clearCache, Generator } from '@jspm/generator';
+import { Generator } from '@jspm/generator';
 import { denoExec } from '#test/deno';
-
-// clearCache();
 
 const generator = new Generator({
   env: ['node', 'deno']
 });
 
-await generator.install('@babel/core@7.14.5');
+await generator.install('@babel/core@7.15.0');
+await generator.install('assert');
 
 const map = generator.getMap();
 
 await denoExec(map, `
   import babel from '@babel/core';
+  import assert from 'assert';
 
-  console.log(babel.transform('var p = 5'));
+  const { code } = babel.transform('var p = 5');
+  assert.strictEqual(code, 'var p = 5;');
 `);

--- a/test/deno/babel.test.js
+++ b/test/deno/babel.test.js
@@ -1,0 +1,18 @@
+import { clearCache, Generator } from '@jspm/generator';
+import { denoExec } from '#test/deno';
+
+// clearCache();
+
+const generator = new Generator({
+  env: ['node', 'deno']
+});
+
+await generator.install('@babel/core@7.14.5');
+
+const map = generator.getMap();
+
+await denoExec(map, `
+  import babel from '@babel/core';
+
+  console.log(babel.transform('var p = 5'));
+`);

--- a/test/deno/self.test.js
+++ b/test/deno/self.test.js
@@ -38,5 +38,5 @@ await denoExec(generator.getMap(), `
   await generator.install({ alias: '@jspm/generator', target: ${JSON.stringify(targetUrl)} });
   const map = generator.getMap();
 
-  assertEquals(map, ${JSON.stringify(map)})
+  assertEquals(map.imports, ${JSON.stringify(map.imports)})
 `);


### PR DESCRIPTION
This one has been a while in the making, but finally got there on it!

Replaces TypeScript with a Babel TypeScript transformer and gets Babel supported fully in the generator and in Deno.