### PR TITLE
Input map override

### DIFF
--- a/self-generate.js
+++ b/self-generate.js
@@ -1,0 +1,18 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+const generator = new Generator({
+  mapUrl: 'about:blank',
+  inputMap: {
+    imports: {
+      '@babel/core': 'https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.8/nodelibs/@empty.js',
+      '@babel/preset-typescript': 'https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.8/nodelibs/@empty.js'
+    }
+  }
+});
+
+await generator.install('@jspm/generator');
+
+
+const json = generator.getMap();
+console.log(json);

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -265,6 +265,15 @@ export default class TraceMap {
       }
     }
 
+    // User import overrides
+    const userImportsMatch = getMapMatch(specifier, this.map.imports);
+    const userImportsResolved = userImportsMatch ? await this.resolver.realPath(new URL(this.map.imports[userImportsMatch] + specifier.slice(userImportsMatch.length), this.map.baseUrl).href) : null;
+    if (userImportsResolved) {
+      this.log('trace', `${specifier} ${parentUrl.href} -> ${userImportsResolved}`);
+      await this.traceUrl(userImportsResolved, parentUrl, env);
+      return userImportsResolved;
+    }
+
     // Own name import
     const pcfg = await this.resolver.getPackageConfig(parentPkgUrl) || {};
     if (pcfg.exports && pcfg.name === pkgName) {
@@ -297,15 +306,6 @@ export default class TraceMap {
       this.log('trace', `${specifier} ${parentUrl.href} -> ${resolved}`);
       await this.traceUrl(resolved, parentUrl, env);
       return resolved;
-    }
-  
-    // User import overrides
-    const userImportsMatch = getMapMatch(specifier, this.map.imports);
-    const userImportsResolved = userImportsMatch ? await this.resolver.realPath(new URL(this.map.imports[userImportsMatch] + specifier.slice(userImportsMatch.length), this.map.baseUrl).href) : null;
-    if (userImportsResolved) {
-      this.log('trace', `${specifier} ${parentUrl.href} -> ${userImportsResolved}`);
-      await this.traceUrl(userImportsResolved, parentUrl, env);
-      return userImportsResolved;
     }
 
     throw new JspmError(`No resolution in map for ${specifier}${importedFrom(parentUrl)}`);

--- a/test/api/input-map-self.test.js
+++ b/test/api/input-map-self.test.js
@@ -1,0 +1,18 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+const generator = new Generator({
+  mapUrl: 'about:blank',
+  inputMap: {
+    imports: {
+      '@babel/core': 'https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.8/nodelibs/@empty.js',
+      '@babel/preset-typescript': 'https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.8/nodelibs/@empty.js'
+    }
+  }
+});
+
+await generator.install('@jspm/generator');
+
+
+const json = generator.getMap();
+assert.ok(JSON.stringify(json).length < 2000);

--- a/test/api/inputmap.test.js
+++ b/test/api/inputmap.test.js
@@ -21,9 +21,8 @@ assert.deepEqual(json, {
     "react-dom": "https://ga.jspm.io/npm:react-dom@17.0.2/index.js"
   },
   "scopes": {
-    "https://ga.jspm.io/": {
+    "https://ga.jspm.io/npm:react-dom@17.0.2/": {
       "object-assign": "https://ga.jspm.io/npm:object-assign@4.1.1/index.js",
-      "react": "https://ga.jspm.io/npm:react@17.0.2/index.js",
       "scheduler": "https://ga.jspm.io/npm:scheduler@0.20.2/index.js"
     }
   }


### PR DESCRIPTION
This ensures that the "imports" of the inputMap, **always** override all deep dependency resolutions of any installs making them fully authoritative.