### PR TITLE
feat: trigger api builds for missing packages, report errored builds

### DIFF
--- a/test/api/self.test.js
+++ b/test/api/self.test.js
@@ -5,9 +5,9 @@ const generator = new Generator({
   mapUrl: import.meta.url
 });
 
-const { staticDeps, dynamicDeps } = await generator.install('@jspm/generator');
+const { staticDeps, dynamicDeps } = await generator.install('@jspm/generator@1.0.0-beta.13');
 
-assert.strictEqual(staticDeps.length, 106);
+assert.strictEqual(staticDeps.length, 112);
 assert.strictEqual(dynamicDeps.length, 0);
 
 const json = generator.getMap();

--- a/test/providers/jspm-err.test.js
+++ b/test/providers/jspm-err.test.js
@@ -1,0 +1,15 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+const generator = new Generator({
+  mapUrl: import.meta.url,
+  env: ['production', 'browser']
+});
+
+try {
+  await generator.install('@elliemae/ds-icons@1.53.3-rc.0');
+  throw new Error('Install should have errorred');
+}
+catch (err) {
+  assert.ok(err.message.includes('with error'))
+}


### PR DESCRIPTION
This ensures that all resolved packages support using the new JSPM build trigger API if their package builds are not yet present on the CDN, with polling.

In addition if the package build was a build error, the error log will be provided as an error message with an issue queue link for more understandable CDN build errors.

This is all jspm provider specific so only affects the provider implementation.