### PR TITLE
feat: support JSX for TS analysis

### DIFF
--- a/src/trace/ts.ts
+++ b/src/trace/ts.ts
@@ -34,7 +34,7 @@ export async function createTsAnalysis (source: string, url: string): Promise<An
       compact: false,
       sourceType: 'module',
       parserOpts: {
-        // plugins: stage3Syntax,
+        plugins: ['jsx'],
         errorRecovery: true
       },
       presets: [[babelPresetTs, {


### PR DESCRIPTION
This adds JSX support **only when using TypeScript** per the fact that Deno supports it.