### PR TITLE
fix: version deduping

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -192,9 +192,9 @@ export class Generator {
       throw new Error(`The URL ${url} has not been traced by this generator instance.`);
     return {
       format: trace.format,
-      staticDeps: Object.keys(trace.deps),
-      dynamicDeps: Object.keys(trace.dynamicDeps),
-      cjsLazyDeps: Object.keys(trace.cjsLazyDeps || {})
+      staticDeps: trace.deps,
+      dynamicDeps: trace.dynamicDeps,
+      cjsLazyDeps: trace.cjsLazyDeps || []
     };
   }
 

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -31,8 +31,8 @@ interface TraceGraph {
 }
 
 interface TraceEntry {
-  deps: Record<string, string | string[]>;
-  dynamicDeps: Record<string, string | string[]>;
+  deps: string[];
+  dynamicDeps: string[];
   // assetDeps: { expr: string, start: number, end: number, assets: string[] }
   hasStaticParent: boolean;
   size: number;
@@ -40,7 +40,7 @@ interface TraceEntry {
   wasCJS: boolean;
   // For cjs modules, the list of hoisted deps
   // this is needed for proper cycle handling
-  cjsLazyDeps: Record<string, string | string[]>;
+  cjsLazyDeps: string[];
   format: 'esm' | 'commonjs' | 'system' | 'json' | 'typescript';
 }
 
@@ -142,25 +142,25 @@ export default class TraceMap {
         const depVisitor = async (url: string, entry: TraceEntry) => {
           list.add(url);
           const parentPkgUrl = await this.resolver.getPackageBase(url);
-          for (const dep of Object.keys(entry.dynamicDeps)) {
+          for (const dep of entry.dynamicDeps) {
             if (dep.indexOf('*') !== -1)
               continue;
-            const resolvedUrl = entry.dynamicDeps[dep] as string;
+            const resolvedUrl = traceResolutions[dep + '##' + url];
             if (isPlain(dep))
               this.map.set(dep, resolvedUrl, parentPkgUrl);
             discoveredDynamics.add(resolvedUrl);
           }
-          for (const dep of Object.keys(entry.deps)) {
+          for (const dep of entry.deps) {
             if (dep.indexOf('*') !== -1)
               continue;
-            const resolvedUrl = entry.deps[dep] as string;
+            const resolvedUrl = traceResolutions[dep + '##' + url];
             if (isPlain(dep))
               this.map.set(dep, resolvedUrl, parentPkgUrl);
           }
-          for (const dep of Object.keys(entry.cjsLazyDeps || {})) {
+          for (const dep of entry.cjsLazyDeps) {
             if (dep.indexOf('*') !== -1)
               continue;
-            const resolvedUrl = entry.cjsLazyDeps[dep] as string;
+            const resolvedUrl = traceResolutions[dep + '##' + url];
             if (isPlain(dep))
               this.map.set(dep, resolvedUrl, parentPkgUrl);
           }
@@ -323,9 +323,9 @@ export default class TraceMap {
 
     const traceEntry: TraceEntry = this.tracedUrls[resolvedUrl] = {
       wasCJS: false,
-      deps: Object.create(null),
-      dynamicDeps: Object.create(null),
-      cjsLazyDeps: null,
+      deps: [],
+      dynamicDeps: [],
+      cjsLazyDeps: [],
       hasStaticParent: true,
       size: NaN,
       integrity: '',
@@ -344,10 +344,8 @@ export default class TraceMap {
     // wasCJS distinct from CJS because it applies to CJS transformed into ESM
     // from the resolver perspective
     const wasCJS = format === 'commonjs' || await this.resolver.wasCommonJS(resolvedUrl);
-    if (wasCJS) {
+    if (wasCJS)
       traceEntry.wasCJS = true;
-      traceEntry.cjsLazyDeps = Object.create(null);
-    }
 
     if (wasCJS && env.includes('import'))
       env = env.map(e => e === 'import' ? 'require' : e);
@@ -377,11 +375,11 @@ export default class TraceMap {
       if (resolved === null) return
 
       if (deps.includes(dep))
-        traceEntry.deps[dep] = resolved;
+        traceEntry.deps.push(dep);
       if (dynamicDeps.includes(dep))
-        traceEntry.dynamicDeps[dep] = resolved;
+        traceEntry.dynamicDeps.push(dep);
       if (cjsLazyDeps && cjsLazyDeps.includes(dep))
-        traceEntry.cjsLazyDeps[dep] = resolved;
+        traceEntry.cjsLazyDeps.push(dep);
     }));
   }
 }

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -374,11 +374,11 @@ export default class TraceMap {
       const resolved = await this.trace(dep, resolvedUrlObj, env);
       if (resolved === null) return
 
-      if (deps.includes(dep))
+      if (deps.includes(dep) && !traceEntry.deps.includes(dep))
         traceEntry.deps.push(dep);
-      if (dynamicDeps.includes(dep))
+      if (dynamicDeps.includes(dep) && !traceEntry.dynamicDeps.includes(dep))
         traceEntry.dynamicDeps.push(dep);
-      if (cjsLazyDeps && cjsLazyDeps.includes(dep))
+      if (cjsLazyDeps && cjsLazyDeps.includes(dep) && !traceEntry.cjsLazyDeps.includes(dep))
         traceEntry.cjsLazyDeps.push(dep);
     }));
   }

--- a/test/api/deduping.test.js
+++ b/test/api/deduping.test.js
@@ -1,0 +1,13 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+const generator = new Generator({
+  mapUrl: import.meta.url,
+  env: ['production', 'browser']
+});
+
+await generator.install({ target: './local/react1' });
+const json = JSON.stringify(generator.getMap(), null, 2);
+
+assert(json.indexOf('react@16') !== -1);
+assert(json.indexOf('react@17') === -1);

--- a/test/api/local/react1/package.json
+++ b/test/api/local/react1/package.json
@@ -1,0 +1,8 @@
+{
+  "exports": "./react1.js",
+  "type": "module",
+  "dependencies": {
+    "react": "16 || 17",
+    "localdep": "../react2"
+  }
+}

--- a/test/api/local/react1/react1.js
+++ b/test/api/local/react1/react1.js
@@ -1,0 +1,2 @@
+import 'react';
+import 'localdep';

--- a/test/api/local/react2/package.json
+++ b/test/api/local/react2/package.json
@@ -1,0 +1,7 @@
+{
+  "exports": "./react2.js",
+  "type": "module",
+  "dependencies": {
+    "react": "16"
+  }
+}

--- a/test/api/local/react2/react2.js
+++ b/test/api/local/react2/react2.js
@@ -1,0 +1,1 @@
+import 'react';


### PR DESCRIPTION
This fixes the version deduping algorithm to ensure that in an application with two packages, one depending on `react: '16 || 17'` and another depending on `react: '16'` that you end up with one version of React at 16, instead of two separate versions of React.

This is achieved with a greedy resolution algorithm, by:

A) If `react: 16 || 17` is installed first, we install the highest version at 17. Then when `react: 16` is hit, we check all other packages using react and down grade them if the ranges accept that, allowing `react: 16` to be used.
B) If `react: 16` is installed first, we install that version. Then when `react: 16 || 17` is hit, we try install react 17 by upgrading all usages of react to this version, we then find out that we can't upgrade the `react: 16` range, so we cancel the 17 upgrade and stick with 16 instead.

That's the core of the "JSPM greedy version constraint solver". Take that, NP complete!