### PR TITLE
feat: baseUrl support

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.15.8",
         "@babel/preset-typescript": "^7.15.0",
         "@jspm/core": "^2.0.0-beta.8",
-        "@jspm/import-map": "^0.2.0",
+        "@jspm/import-map": "^0.3.0",
         "es-module-lexer": "^0.9.3",
         "make-fetch-happen": "^8.0.3",
         "sver": "^1.8.3",
@@ -480,9 +480,9 @@
       "integrity": "sha512-xul0U82Hg0nsTUTrBhJ35J1IBzCKBKv1JSaDMtJGqYi/x+Q7HqpwXZ5is5Vfd7HW60ARBAQETa29UUbpuF0jbA=="
     },
     "node_modules/@jspm/import-map": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@jspm/import-map/-/import-map-0.2.1.tgz",
-      "integrity": "sha512-C67RM4qys70GAQ0W2pUVX0MJVEMEGhLI5v7xnwX8Fk5acrI9RS6F417r0lTfPWSK2+XswjHiCi9dPpeP2BTZXA=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@jspm/import-map/-/import-map-0.3.0.tgz",
+      "integrity": "sha512-CUtprynzcnXYxkVpSNvmBIAY+Tpz90xtedxDW8KTur3XzN244QbyIo/xnrTs7mIsWejyxv2uQw7SSWuhOGa+xw=="
     },
     "node_modules/@npmcli/move-file": {
       "version": "1.1.2",
@@ -2759,9 +2759,9 @@
       "integrity": "sha512-xul0U82Hg0nsTUTrBhJ35J1IBzCKBKv1JSaDMtJGqYi/x+Q7HqpwXZ5is5Vfd7HW60ARBAQETa29UUbpuF0jbA=="
     },
     "@jspm/import-map": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/@jspm/import-map/-/import-map-0.2.1.tgz",
-      "integrity": "sha512-C67RM4qys70GAQ0W2pUVX0MJVEMEGhLI5v7xnwX8Fk5acrI9RS6F417r0lTfPWSK2+XswjHiCi9dPpeP2BTZXA=="
+      "version": "0.3.0",
+      "resolved": "https://registry.npmjs.org/@jspm/import-map/-/import-map-0.3.0.tgz",
+      "integrity": "sha512-CUtprynzcnXYxkVpSNvmBIAY+Tpz90xtedxDW8KTur3XzN244QbyIo/xnrTs7mIsWejyxv2uQw7SSWuhOGa+xw=="
     },
     "@npmcli/move-file": {
       "version": "1.1.2",

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.15.8",
         "@babel/preset-typescript": "^7.15.0",
         "@jspm/core": "^2.0.0-beta.8",
-        "@jspm/import-map": "^0.3.0",
+        "@jspm/import-map": "^0.3.1",
         "es-module-lexer": "^0.9.3",
         "make-fetch-happen": "^8.0.3",
         "sver": "^1.8.3",
@@ -480,9 +480,9 @@
       "integrity": "sha512-xul0U82Hg0nsTUTrBhJ35J1IBzCKBKv1JSaDMtJGqYi/x+Q7HqpwXZ5is5Vfd7HW60ARBAQETa29UUbpuF0jbA=="
     },
     "node_modules/@jspm/import-map": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@jspm/import-map/-/import-map-0.3.0.tgz",
-      "integrity": "sha512-CUtprynzcnXYxkVpSNvmBIAY+Tpz90xtedxDW8KTur3XzN244QbyIo/xnrTs7mIsWejyxv2uQw7SSWuhOGa+xw=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@jspm/import-map/-/import-map-0.3.1.tgz",
+      "integrity": "sha512-/VE+hMxNc8qUd+C6k6I9PA6kWJbnL4YHbxiMWZsG2mtxco+rzA36lJLwpkNq9mAnxdqa9RUrUiNcfrTjaFCBGw=="
     },
     "node_modules/@npmcli/move-file": {
       "version": "1.1.2",
@@ -2759,9 +2759,9 @@
       "integrity": "sha512-xul0U82Hg0nsTUTrBhJ35J1IBzCKBKv1JSaDMtJGqYi/x+Q7HqpwXZ5is5Vfd7HW60ARBAQETa29UUbpuF0jbA=="
     },
     "@jspm/import-map": {
-      "version": "0.3.0",
-      "resolved": "https://registry.npmjs.org/@jspm/import-map/-/import-map-0.3.0.tgz",
-      "integrity": "sha512-CUtprynzcnXYxkVpSNvmBIAY+Tpz90xtedxDW8KTur3XzN244QbyIo/xnrTs7mIsWejyxv2uQw7SSWuhOGa+xw=="
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/@jspm/import-map/-/import-map-0.3.1.tgz",
+      "integrity": "sha512-/VE+hMxNc8qUd+C6k6I9PA6kWJbnL4YHbxiMWZsG2mtxco+rzA36lJLwpkNq9mAnxdqa9RUrUiNcfrTjaFCBGw=="
     },
     "@npmcli/move-file": {
       "version": "1.1.2",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@babel/core": "^7.15.8",
     "@babel/preset-typescript": "^7.15.0",
     "@jspm/core": "^2.0.0-beta.8",
-    "@jspm/import-map": "^0.3.0",
+    "@jspm/import-map": "^0.3.1",
     "es-module-lexer": "^0.9.3",
     "make-fetch-happen": "^8.0.3",
     "sver": "^1.8.3",

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "@babel/core": "^7.15.8",
     "@babel/preset-typescript": "^7.15.0",
     "@jspm/core": "^2.0.0-beta.8",
-    "@jspm/import-map": "^0.2.0",
+    "@jspm/import-map": "^0.3.0",
     "es-module-lexer": "^0.9.3",
     "make-fetch-happen": "^8.0.3",
     "sver": "^1.8.3",

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -333,7 +333,7 @@ export class Generator {
     }
     this.baseUrl = typeof baseUrl === 'string' ? new URL(baseUrl, _baseUrl) : baseUrl;
     if (!this.baseUrl.pathname.endsWith('/')) {
-      this.baseUrl = new URL(this.baseUrl);
+      this.baseUrl = new URL(this.baseUrl.href);
       this.baseUrl.pathname += '/';
     }
     this.mapUrl = typeof mapUrl === 'string' ? new URL(mapUrl, this.baseUrl) : mapUrl;
@@ -497,7 +497,7 @@ export class Generator {
 
   getMap () {
     const map = this.traceMap.map.clone();
-    map.flatten(this.rootUrl ? this.rootUrl : this.baseUrl, !!this.rootUrl);
+    map.flatten(this.rootUrl ? this.rootUrl : this.baseUrl);
     if (this.rootUrl)
       map.rebase(this.rootUrl.href, true);
     map.sort();

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,4 +1,4 @@
-import { baseUrl } from "./common/url.js";
+import { baseUrl as _baseUrl } from "./common/url.js";
 import { ExactPackage, toPackageTarget } from "./install/package.js";
 import TraceMap from './trace/tracemap.js';
 import { LockResolutions } from './install/installer.js';
@@ -12,9 +12,18 @@ import { JspmError } from "./common/err.js";
 
 export interface GeneratorOptions {
   /**
-   * The URL of the import map itself, used to construct relative
-   * import map URLs.
-   * Default: pathTofileURL(process.cwd() + '/')
+   * The URL to use for resolutions without a parent context.
+   * 
+   * Defaults to mapUrl or the process base URL.
+   * 
+   * Also determines the default scoping base for the import map when flattening.
+   */
+  baseUrl?: URL | string;
+
+  /**
+   * The URL of the import map itself, used to construct relative import map URLs.
+   * 
+   * Defaults to the base URL.
    * 
    * The `mapUrl` is used in order to output relative URLs for modules located on the same
    * host as the import map.
@@ -175,16 +184,17 @@ export interface GeneratorOptions {
    * });
    * ```
    * 
-   * It is also useful for local monorepo patterns where all local packages should be located locally:
+   * It is also useful for local monorepo patterns where all local packages should be located locally.
+   * When referencing local paths, the baseUrl configuration option is used as the URL parent.
    * 
    * ```js
-   * const pkgBaseUrl = new URL('./packages', import.meta.url).href;
-   * 
    * const generator = new Generator({
+   *   mapUrl: new URL('./app.html', import.meta.url),
+   *   baseUrl: new URL('../', import.meta.url),
    *   resolutions: {
-   *     '@company/pkgA': `${pkgBaseUrl}/pkgA`,
-   *     '@company/pkgB': `${pkgBaseUrl}/pkgB`
-   *     '@company/pkgC': `${pkgBaseUrl}/pkgC`
+   *     '@company/pkgA': `./pkgA`,
+   *     '@company/pkgB': `./pkgB`
+   *     '@company/pkgC': `./pkgC`
    *   }
    * })
    * ```
@@ -248,6 +258,7 @@ export function clearCache () {
 
 export class Generator {
   traceMap: TraceMap;
+  baseUrl: URL;
   mapUrl: URL;
   rootUrl: URL | null;
   finishInstall: (success: boolean) => Promise<boolean | { pjsonChanged: boolean, lock: LockResolutions }> | null = null;
@@ -279,7 +290,8 @@ export class Generator {
    * ```
    */
   constructor ({
-    mapUrl = baseUrl,
+    baseUrl,
+    mapUrl,
     rootUrl = undefined,
     inputMap = undefined,
     env = ['browser', 'development', 'module'],
@@ -304,8 +316,28 @@ export class Generator {
       }
     }
     this.logStream = logStream;
-    this.mapUrl = typeof mapUrl === 'string' ? new URL(mapUrl, baseUrl) : mapUrl;
-    this.rootUrl = typeof rootUrl === 'string' ? new URL(rootUrl, baseUrl) : rootUrl || null;
+
+    if (mapUrl && !baseUrl) {
+      mapUrl = typeof mapUrl === 'string' ? new URL(mapUrl, _baseUrl) : mapUrl;
+      try {
+        baseUrl = new URL('./', mapUrl);
+      } catch {
+        baseUrl = new URL(mapUrl + '/');
+      }
+    }
+    else if (baseUrl && !mapUrl) {
+      mapUrl = baseUrl;
+    }
+    else if (!mapUrl && !baseUrl) {
+      baseUrl = mapUrl = _baseUrl;
+    }
+    this.baseUrl = typeof baseUrl === 'string' ? new URL(baseUrl, _baseUrl) : baseUrl;
+    if (!this.baseUrl.pathname.endsWith('/')) {
+      this.baseUrl = new URL(this.baseUrl);
+      this.baseUrl.pathname += '/';
+    }
+    this.mapUrl = typeof mapUrl === 'string' ? new URL(mapUrl, this.baseUrl) : mapUrl;
+    this.rootUrl = typeof rootUrl === 'string' ? new URL(rootUrl, this.baseUrl) : rootUrl || null;
     if (!this.mapUrl.pathname.endsWith('/')) {
       try {
         this.mapUrl = new URL('./', this.mapUrl);
@@ -314,6 +346,7 @@ export class Generator {
       }
     }
     this.traceMap = new TraceMap(this.mapUrl, {
+      baseUrl: this.baseUrl,
       stdlib,
       env,
       defaultProvider,
@@ -341,7 +374,7 @@ export class Generator {
     if (this.installCnt++ === 0)
       this.finishInstall = await this.traceMap.startInstall();
     try {
-      await this.traceMap.trace(specifier, parentUrl || this.mapUrl);
+      await this.traceMap.trace(specifier, parentUrl || this.baseUrl);
     }
     catch (e) {
       error = true;
@@ -427,9 +460,9 @@ export class Generator {
    * @param parentUrl ParentURL of module to resolve
    * @returns Resolved URL string
    */
-  resolve (specifier: string, parentUrl: URL | string = baseUrl) {
+  resolve (specifier: string, parentUrl: URL | string = this.baseUrl) {
     if (typeof parentUrl === 'string')
-      parentUrl = new URL(parentUrl, baseUrl);
+      parentUrl = new URL(parentUrl, this.baseUrl);
     const resolved = this.traceMap.map.resolve(specifier, parentUrl);
     if (resolved === null)
       throw new JspmError(`Unable to resolve "${specifier}" from ${parentUrl.href}`, 'MODULE_NOT_FOUND');
@@ -464,12 +497,10 @@ export class Generator {
 
   getMap () {
     const map = this.traceMap.map.clone();
+    map.flatten(this.rootUrl ? this.rootUrl : this.baseUrl, !!this.rootUrl);
     if (this.rootUrl)
       map.rebase(this.rootUrl.href, true);
-    else
-      map.rebase();
     map.sort();
-    map.flatten();
     return map.toJSON();
   }
 }
@@ -563,7 +594,7 @@ async function installToTarget (this: Generator, install: Install | string) {
     throw new Error('All installs require a "target" string.');
   if (install.subpath !== undefined && (typeof install.subpath !== 'string' || (install.subpath !== '.' && !install.subpath.startsWith('./'))))
     throw new Error(`Install subpath "${install.subpath}" must be a string equal to "." or starting with "./".${typeof install.subpath === 'string' ? `\nTry setting the subpath to "./${install.subpath}"` : ''}`);
-  const { alias, target, subpath } = await toPackageTarget(this.traceMap.resolver, install.target, this.mapUrl.href);
+  const { alias, target, subpath } = await toPackageTarget(this.traceMap.resolver, install.target, this.baseUrl.href);
   return {
     alias: install.alias || alias,
     target,

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -54,6 +54,8 @@ function getInstalledRanges (installedRanges: InstalledRanges, target: PackageTa
 }
 
 export interface InstallOptions {
+  // default base for relative installs
+  baseUrl: URL;
   // create a lockfile if it does not exist
   lock?: LockFile;
   // do not modify the lockfile
@@ -350,8 +352,9 @@ export class Installer {
         return existingUrl;
     }
 
-    if (this.resolutions[pkgName])
-      return this.installTarget(pkgName, newPackageTarget(this.resolutions[pkgName], pkgUrl, pkgName), pkgUrl, false, parentUrl);
+    if (this.resolutions[pkgName]) {
+      return this.installTarget(pkgName, newPackageTarget(this.resolutions[pkgName], this.opts.baseUrl.href, pkgName), pkgUrl, false, parentUrl);
+    }
 
     const pcfg = await this.resolver.getPackageConfig(pkgUrl) || {};
 

--- a/test/api/localresolutions.test.js
+++ b/test/api/localresolutions.test.js
@@ -2,15 +2,16 @@ import { Generator } from '@jspm/generator';
 import assert from 'assert';
 
 const generator = new Generator({
+  baseUrl: new URL('../', import.meta.url),
   mapUrl: import.meta.url,
   defaultProvider: 'jspm',
   env: ['production', 'browser'],
   resolutions: {
-    dep: new URL('./local/dep/', import.meta.url).href
+    dep: './api/local/dep/'
   }
 });
 
-await generator.install({ target: './local/pkg', subpath: './withdep' });
+await generator.install({ target: './api/local/pkg', subpath: './withdep' });
 const json = generator.getMap();
 
-assert.strictEqual(json.scopes['./'].dep, './local/dep/main.js');
+assert.strictEqual(json.scopes['./api/'].dep, './local/dep/main.js');

--- a/test/api/localresolutions.test.js
+++ b/test/api/localresolutions.test.js
@@ -13,5 +13,4 @@ const generator = new Generator({
 
 await generator.install({ target: './api/local/pkg', subpath: './withdep' });
 const json = generator.getMap();
-
-assert.strictEqual(json.scopes['./'].dep, './local/dep/main.js');
+assert.strictEqual(json.scopes['../'].dep, './local/dep/main.js');

--- a/test/api/localresolutions.test.js
+++ b/test/api/localresolutions.test.js
@@ -14,4 +14,4 @@ const generator = new Generator({
 await generator.install({ target: './api/local/pkg', subpath: './withdep' });
 const json = generator.getMap();
 
-assert.strictEqual(json.scopes['./api/'].dep, './local/dep/main.js');
+assert.strictEqual(json.scopes['./'].dep, './local/dep/main.js');


### PR DESCRIPTION
This adds support for a `baseUrl` option separate from the `mapUrl` option, which allows setting a base for package install resolutions. Simplifies the `"resolutions"` field to more easily support relative package installs to a shared base. Also serves as the scope flattening base.