### PR TITLE
Default to finding correct IPFS API

### DIFF
--- a/README.md
+++ b/README.md
@@ -343,12 +343,12 @@ await generator.install("@react-three/fiber@7")
 
 #### ipfsAPI
 
-> Type: String</br/>
-Default: '/ip4/127.0.0.1/tcp/45005'
+> Type: String | String[]</br/>
+Default: ['/ip4/127.0.0.1/tcp/45005', '/ip4/127.0.0.1/tcp/5001']
 
-When installing IPFS URLs, this configures the IPFS Node API multiaddress string to use.
+When installing IPFS URLs, this configures the IPFS Node API multiaddress or list of fallback addresses to connect to.
 
-Defaults to the Brave IPFS Node API which can be enabled from brave://ipfs-internals/ in the Brave Browser.
+Defaults to trying the Brave IPFS node then the local IPFS node. The API which can be enabled from brave://ipfs-internals/ in the Brave Browser.
 
 #### defaultProvider
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -227,11 +227,16 @@ export interface GeneratorOptions {
    */
   ignore?: string[];
   /**
-   * When installing packages over IPFS, sets the IPFS node API HTTP interface to use
+   * When installing packages over IPFS, sets the IPFS node API HTTP interface to use,
+   * or a list of API URLs to try connect to.
+   * 
+   * Default: ['/ip4/127.0.0.1/tcp/45005', '/ip4/127.0.0.1/tcp/5001']
+   * 
    * Defaults to the Brave Browser interface at /ip4/127.0.0.1/tcp/45005, when IPFS is
-   * enabled in Brave Browser via brave://ipfs-internals/
+   * enabled in Brave Browser via brave://ipfs-internals/, followed by trying the local
+   * IPFS node.
    */
-  ipfsAPI?: string;
+  ipfsAPI?: string | string[];
 }
 
 export interface ModuleAnalysis {


### PR DESCRIPTION
This updates the IPFS support to automatically select the best IPFS API to use by first trying the Brave browser API, falling back to the local IPFS Node, and with a better error message on failure.