### PR TITLE
feat: fetch vscode support

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
   "imports": {
     "#fetch": {
       "source": {
+        "vscode": "./lib/common/fetch-vscode.js",
         "deno": "./lib/common/fetch-deno.js",
         "node": "./lib/common/fetch-node.js",
-        "vscode": "./lib/common/fetch-vscode.js",
         "default": "./lib/common/fetch-native.js"
       },
       "default": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,7 @@
       "source": {
         "deno": "./lib/common/fetch-deno.js",
         "node": "./lib/common/fetch-node.js",
+        "vscode": "./lib/common/fetch-vscode.js",
         "default": "./lib/common/fetch-native.js"
       },
       "default": {

--- a/src/common/fetch-vscode.ts
+++ b/src/common/fetch-vscode.ts
@@ -1,0 +1,70 @@
+import { fetch as _fetch } from './fetch-native.js';
+export { clearCache } from './fetch-native.js';
+
+function sourceResponse (buffer) {
+  return {
+    status: 200,
+    async text () {
+      return buffer.toString();
+    },
+    async json () {
+      return JSON.parse(buffer.toString());
+    },
+    arrayBuffer () {
+      return buffer.buffer || buffer;
+    }
+  };
+}
+
+const dirResponse = {
+  status: 200,
+  async text () {
+    return '';
+  },
+  async json () {
+    throw new Error('Not JSON');
+  },
+  arrayBuffer () {
+    return new ArrayBuffer(0);
+  }
+};
+
+const vscode = require('vscode');
+
+export const fetch = async function (url: URL, opts?: Record<string, any>) {
+  if (!opts)
+    throw new Error('Always expect fetch options to be passed');
+  const urlString = url.toString();
+  const protocol = urlString.slice(0, urlString.indexOf(':') + 1);
+  switch (protocol) {
+    case 'ipfs:':
+      throw new Error('IPFS Support for VSCode not yet implemented');
+    case 'file:':
+      if (urlString.endsWith('/')) {
+        try {
+          await vscode.workspace.fs.readFile(vscode.Uri.parse(urlString));
+          return { status: 404, statusText: 'Directory does not exist' };
+        }
+        catch (e) {
+          if (e.code === 'FileIsADirectory')
+            return dirResponse;
+          throw e;
+        }
+      }
+      try {
+        return sourceResponse(new TextDecoder().decode(await vscode.workspace.fs.readFile(vscode.Uri.parse(urlString))));
+      }
+      catch (e) {
+        if (e.code === 'FileIsADirectory')
+          return dirResponse;
+        if (e.code === 'Unavailable')
+          return { status: 404, statusText: e.toString() };
+        return { status: 500, statusText: e.toString() };
+      }
+    case 'data:':
+    case 'http:':
+    case 'https:':
+      // @ts-ignore
+      return _fetch(url, opts);
+  }
+}


### PR DESCRIPTION
This adds a fetch implementation for VSCode, so that the generator can be built and run in VSCode environments as an extension.