### PR TITLE
Possible determinism fix for require / import

### DIFF
--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -148,7 +148,7 @@ export default class TraceMap {
             const resolvedUrl = traceResolutions[dep + '##' + url];
             if (isPlain(dep)) {
               const existing = this.map.scopes[parentPkgUrl]?.[dep];
-              if (!existing || existing && existing !== resolvedUrl && this.tracedUrls?.[url]?.wasCJS)
+              if (!existing || existing !== resolvedUrl && this.tracedUrls?.[url]?.wasCJS)
                 this.map.set(dep, resolvedUrl, parentPkgUrl);
             }
             discoveredDynamics.add(resolvedUrl);
@@ -159,7 +159,7 @@ export default class TraceMap {
             const resolvedUrl = traceResolutions[dep + '##' + url];
             if (isPlain(dep)) {
               const existing = this.map.scopes[parentPkgUrl]?.[dep];
-              if (!existing || existing && existing !== resolvedUrl && this.tracedUrls?.[url]?.wasCJS)
+              if (!existing || existing !== resolvedUrl && this.tracedUrls?.[url]?.wasCJS)
                 this.map.set(dep, resolvedUrl, parentPkgUrl);
             }
           }
@@ -169,7 +169,7 @@ export default class TraceMap {
             const resolvedUrl = traceResolutions[dep + '##' + url];
             if (isPlain(dep)) {
               const existing = this.map.scopes[parentPkgUrl]?.[dep];
-              if (!existing || existing && existing !== resolvedUrl && this.tracedUrls?.[url]?.wasCJS)
+              if (!existing || existing !== resolvedUrl && this.tracedUrls?.[url]?.wasCJS)
                 this.map.set(dep, resolvedUrl, parentPkgUrl);
             }
           }

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -160,7 +160,7 @@ export default class TraceMap {
             if (isPlain(dep)) {
               const existing = this.map.scopes[parentPkgUrl]?.[dep];
               if (!existing || existing && existing !== resolvedUrl && this.tracedUrls?.[url]?.wasCJS)
-              this.map.set(dep, resolvedUrl, parentPkgUrl);
+                this.map.set(dep, resolvedUrl, parentPkgUrl);
             }
           }
           for (const dep of entry.cjsLazyDeps) {
@@ -170,7 +170,7 @@ export default class TraceMap {
             if (isPlain(dep)) {
               const existing = this.map.scopes[parentPkgUrl]?.[dep];
               if (!existing || existing && existing !== resolvedUrl && this.tracedUrls?.[url]?.wasCJS)
-              this.map.set(dep, resolvedUrl, parentPkgUrl);
+                this.map.set(dep, resolvedUrl, parentPkgUrl);
             }
           }
         }

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -146,23 +146,32 @@ export default class TraceMap {
             if (dep.indexOf('*') !== -1)
               continue;
             const resolvedUrl = traceResolutions[dep + '##' + url];
-            if (isPlain(dep))
-              this.map.set(dep, resolvedUrl, parentPkgUrl);
+            if (isPlain(dep)) {
+              const existing = this.map.scopes[parentPkgUrl]?.[dep];
+              if (!existing || existing && existing !== resolvedUrl && this.tracedUrls?.[url]?.wasCJS)
+                this.map.set(dep, resolvedUrl, parentPkgUrl);
+            }
             discoveredDynamics.add(resolvedUrl);
           }
           for (const dep of entry.deps) {
             if (dep.indexOf('*') !== -1)
               continue;
             const resolvedUrl = traceResolutions[dep + '##' + url];
-            if (isPlain(dep))
+            if (isPlain(dep)) {
+              const existing = this.map.scopes[parentPkgUrl]?.[dep];
+              if (!existing || existing && existing !== resolvedUrl && this.tracedUrls?.[url]?.wasCJS)
               this.map.set(dep, resolvedUrl, parentPkgUrl);
+            }
           }
           for (const dep of entry.cjsLazyDeps) {
             if (dep.indexOf('*') !== -1)
               continue;
             const resolvedUrl = traceResolutions[dep + '##' + url];
-            if (isPlain(dep))
+            if (isPlain(dep)) {
+              const existing = this.map.scopes[parentPkgUrl]?.[dep];
+              if (!existing || existing && existing !== resolvedUrl && this.tracedUrls?.[url]?.wasCJS)
               this.map.set(dep, resolvedUrl, parentPkgUrl);
+            }
           }
         }
         const seen = new Set<string>();


### PR DESCRIPTION
This fix uses the logic that the require condition should always beat the import condition when both are resolved for the same scoping.

An alternative fix could be to rescope the parent specifically, and that fix would follow a similar code path.

@vovacodes perhaps you can verify if this works for you further?