### PR TITLE
feat: devDependencies local scoping

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,10 +9,10 @@
     "tsc:watch": "tsc -p . --watch",
     "typedoc": "typedoc src/generator.ts",
     "rollup": "rollup -c",
-    "build": "npm run tsc && npm run rollup",
+    "build": "npm run tsc ; npm run rollup",
     "cache-clear": "node cache-clear.js",
     "self-generate": "node self-generate.js",
-    "test": "npm run test:node && npm run test:browser",
+    "test": "npm run test:node ; npm run test:browser",
     "test:node": "node -C source test/test.js",
     "test:browser": "node test/server.mjs",
     "test:watch": "cross-env WATCH_MODE=1 node test/server.mjs"

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -367,7 +367,7 @@ export class Installer {
     }
 
     // package dependencies
-    const installTarget = pcfg.dependencies?.[pkgName] || pcfg.peerDependencies?.[pkgName] || pcfg.optionalDependencies?.[pkgName] || pcfg.devDependencies?.[pkgName];
+    const installTarget = pcfg.dependencies?.[pkgName] || pcfg.peerDependencies?.[pkgName] || pcfg.optionalDependencies?.[pkgName] || pkgUrl === this.installBaseUrl && pcfg.devDependencies?.[pkgName];
     if (installTarget) {
       const target = newPackageTarget(installTarget, pkgUrl, pkgName);
       return this.installTarget(pkgName, target, pkgUrl, false, parentUrl);

--- a/test/api/devdependencies.test.js
+++ b/test/api/devdependencies.test.js
@@ -1,0 +1,12 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+const generator = new Generator({
+  mapUrl: new URL('./local/pkg/asdf', import.meta.url),
+  defaultProvider: 'jspm',
+  env: ['production', 'browser']
+});
+
+await generator.traceInstall('localpkg/jquery');
+const json = generator.getMap();
+assert.ok(json.scopes['./'].jquery.includes('@2'));

--- a/test/api/local/pkg/jquery.js
+++ b/test/api/local/pkg/jquery.js
@@ -1,0 +1,1 @@
+import 'jquery';

--- a/test/api/local/pkg/package.json
+++ b/test/api/local/pkg/package.json
@@ -5,7 +5,8 @@
     "./withdep": "./b.js",
     "./withdep2": "./c.js",
     "./remotedep": "./d.js",
-    "./cjs": "./e.cjs"
+    "./cjs": "./e.cjs",
+    "./jquery": "./jquery.js"
   },
   "imports": {
     "#cjsdep": "./f.cjs"
@@ -14,5 +15,8 @@
     "dep": "file:../dep",
     "dep2": "../dep",
     "react": "https://ga.jspm.io/npm:react@16.14.0"
+  },
+  "devDependencies": {
+    "jquery": "2"
   }
 }


### PR DESCRIPTION
This adds local scoping for `"devDependencies"` to ensure that their resolutions are only followed when the current package scope matches the generator installer package scope.

Resolves https://github.com/jspm/generator/issues/84.