### PR TITLE
fix: HTML generation issues

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
     "tsc:watch": "tsc -p . --watch",
     "typedoc": "typedoc src/generator.ts",
     "rollup": "rollup -c",
-    "build": "npm run tsc && npm run rollup",
+    "build": "npm run tsc ; npm run rollup",
     "cache-clear": "node cache-clear.js",
     "self-generate": "node self-generate.js",
     "test": "npm run test:node ; npm run test:browser",

--- a/src/html/analyze.ts
+++ b/src/html/analyze.ts
@@ -1,6 +1,6 @@
 import { parseStyled } from '../common/json.js';
 import { SourceStyle } from '../common/source-style.js';
-import { baseUrl } from '../common/url.js';
+import { baseUrl, isPlain } from '../common/url.js';
 import { ParsedAttribute, ParsedTag, parseHtml } from './lexer.js';
 // @ts-ignore
 import { parse } from 'es-module-lexer/js';
@@ -83,7 +83,7 @@ export function analyzeHtml (source: string, url: URL = baseUrl): HtmlAnalysis {
             if (esmsSrcRegEx.test(src))
               analysis.esModuleShims = { start: tag.start, end: tag.end, attrs: toHtmlAttrs(source, tag.attributes) };
             else
-              analysis.staticImports.add(src);
+              analysis.staticImports.add(isPlain(src) ? './' + src : src);
           }
           else {
             const [imports] = parse(source.slice(tag.innerStart, tag.innerEnd)) || [];

--- a/src/providers/jspm.ts
+++ b/src/providers/jspm.ts
@@ -64,7 +64,7 @@ async function ensureBuild (pkg: ExactPackage, fetchOpts: any) {
 
   // no package.json AND no build error -> post a build request
   // once the build request has been posted, try polling for up to 2 mins
-  const buildRes = await fetch(`${apiUrl}/build/${pkg.name}@${pkg.version}`);
+  const buildRes = await fetch(`${apiUrl}build/${pkg.name}@${pkg.version}`, fetchOpts);
   if (!buildRes.ok && buildRes.status !== 403) {
     const err = (await buildRes.json()).error;
     throw new JspmError(`Unable to request the JSPM API for a build of ${pkgStr}, with error: ${err}.`);


### PR DESCRIPTION
This fixes a couple of bugs with the HTML generation, namely:

* `<script type="module" src="main.js">` must resolve `./main.js` not the external package `main.js`.
* `fetchOpts` were not being provided to `ensureBuild` in the JSPM provider, causing an error