### PR TITLE
feat: lockfile support, htmlGenerate lock inference

### DIFF
--- a/chompfile.toml
+++ b/chompfile.toml
@@ -39,6 +39,7 @@ deps = ['src/#.ts']
 template = 'swc'
 [task.template-options.config]
 inlineSourcesContent = false
+'jsc.target' = 'es2019'
 
 [[task]]
 name = 'test'
@@ -53,7 +54,6 @@ name = 'unit:#'
 serial = true
 deps = ['test/#.test.js', 'lib/**/*.js', 'dist/*']
 display = 'dot'
-stdio = 'stderr-only'
 run = 'node -C source $DEP'
 
 [[task]]

--- a/src/common/url.ts
+++ b/src/common/url.ts
@@ -36,7 +36,9 @@ function matchesRoot (url: URL, baseUrl: URL) {
 
 export function relativeUrl (url: URL, baseUrl: URL, absolute = false) {
   const href = url.href;
-  const baseUrlHref = baseUrl.href;
+  let baseUrlHref = baseUrl.href;
+  if (!baseUrlHref.endsWith('/'))
+    baseUrlHref += '/';
   if (href.startsWith(baseUrlHref))
     return (absolute ? '/' : './') + href.slice(baseUrlHref.length);
   if (!matchesRoot(url, baseUrl))

--- a/src/install/lock.ts
+++ b/src/install/lock.ts
@@ -1,0 +1,118 @@
+import { IImportMap } from "@jspm/import-map";
+import { throwInternalError } from "../common/err.js";
+import { relativeUrl } from "../common/url.js";
+import { Resolver } from "../trace/resolver.js";
+
+export interface LockResolutions {
+  [pkgUrl: string]: Record<string, string>;
+}
+
+export function normalizeLock (resolutions: LockResolutions, baseUrl: URL) {
+  const outResolutions: LockResolutions = {};
+  for (const pkgUrl of Object.keys(resolutions)) {
+    const normalizedPkgUrl = relativeUrl(new URL(pkgUrl), baseUrl);
+    const pkgResolutions = outResolutions[normalizedPkgUrl] = {};
+    for (const key of Object.keys(resolutions[pkgUrl])) {
+      pkgResolutions[key] = relativeUrl(new URL(resolutions[pkgUrl][key]), baseUrl);
+    }
+  }
+  return outResolutions;
+}
+
+export function resolveLock (resolutions: LockResolutions, baseUrl: URL) {
+  const outResolutions: LockResolutions = {};
+  for (const pkgUrl of Object.keys(resolutions)) {
+    const resolvedPkgUrl = new URL(pkgUrl, baseUrl).href;
+    const pkgResolutions = outResolutions[resolvedPkgUrl] = {};
+    for (const key of Object.keys(resolutions[pkgUrl])) {
+      pkgResolutions[key] = new URL(resolutions[pkgUrl][key], baseUrl).href;
+    }
+  }
+  return outResolutions;
+}
+
+export function pruneResolutions (resolutions: LockResolutions, to: [string, string][]): LockResolutions {
+  const newResolutions: LockResolutions = {};
+  for (const [name, parent] of to) {
+    const resolution = resolutions[parent][name];
+    newResolutions[parent] = newResolutions[parent] || {};
+    newResolutions[parent][name] = resolution;
+  }
+  return newResolutions;
+}
+
+export function getResolution (resolutions: LockResolutions, name: string, pkgUrl: string): string | undefined {
+  if (!pkgUrl.endsWith('/'))
+    throwInternalError(pkgUrl);
+  resolutions[pkgUrl] = resolutions[pkgUrl] || {};
+  return resolutions[pkgUrl][name];
+}
+
+export function stringResolution (resolution: string, subpath: string | null) {
+  if (!resolution.endsWith('/'))
+    throwInternalError(resolution);
+  return subpath ? resolution.slice(0, -1) + '|' + subpath : resolution;
+}
+
+export function setResolution (resolutions: LockResolutions, name: string, pkgUrl: string, resolution: string, subpath: string | null) {
+  if (!pkgUrl.endsWith('/'))
+    throwInternalError(pkgUrl);
+  resolutions[pkgUrl] = resolutions[pkgUrl] || {};
+  const strResolution = stringResolution(resolution, subpath);
+  if (resolutions[pkgUrl][name] === strResolution)
+    return false;
+  resolutions[pkgUrl][name] = strResolution;
+  return true;
+}
+
+function resolveUrl (url: string, mapUrl: URL, rootUrl: URL) {
+  if (url.startsWith('//'))
+    return new URL(url, rootUrl);
+  if (url.startsWith('/'))
+    return new URL(url.slice(1), rootUrl);
+  return new URL(url, mapUrl);
+}
+
+export async function extractLockAndMap (map: IImportMap, preloadUrls: string[], mapUrl: URL, rootUrl: URL, resolver: Resolver): Promise<{ lock: LockResolutions, maps: IImportMap }> {
+  const lock: LockResolutions = {};
+  const maps: IImportMap = { imports: {}, scopes: {} };
+
+  for (const key of Object.keys(map.imports || {})) {
+    const targetUrl = resolveUrl(map.imports[key], mapUrl, rootUrl).href;
+    const providerPkg = resolver.parseUrlPkg(targetUrl);
+    if (providerPkg) {
+      const pkgUrl = await resolver.getPackageBase(mapUrl.href);
+      setResolution(lock, key, pkgUrl, resolver.pkgToUrl(providerPkg.pkg, providerPkg.source), '');
+    }
+    else {
+      maps.imports[key] = targetUrl;
+    }
+  }
+
+  for (const scopeUrl of Object.keys(map.scopes || {})) {
+    const resolvedScopeUrl = resolveUrl(scopeUrl, mapUrl, rootUrl).href;
+    const scope = map.scopes[scopeUrl];
+    for (const key of Object.keys(scope)) {
+      const targetUrl = resolveUrl(scope[key], mapUrl, rootUrl).href;
+      const providerPkg = resolver.parseUrlPkg(targetUrl);
+      if (providerPkg) {
+        const scopePkgUrl = await resolver.getPackageBase(resolvedScopeUrl);
+        setResolution(lock, key, scopePkgUrl, resolver.pkgToUrl(providerPkg.pkg, providerPkg.source), '');
+      }
+      else {
+        (maps.scopes[resolvedScopeUrl] = map.scopes[resolvedScopeUrl] || {})[key] = targetUrl;
+      }
+    }
+  }
+
+  // TODO: allow preloads to inform used versions somehow
+  // for (const url of preloadUrls) {
+  //   const resolved = resolveUrl(url, mapUrl, rootUrl).href;
+  //   const providerPkg = resolver.parseUrlPkg(resolved);
+  //   if (providerPkg) {
+  //     const pkgUrl = await resolver.getPackageBase(mapUrl.href);
+  //   }
+  // }
+
+  return { lock, maps };
+}

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -312,7 +312,7 @@ export default class TraceMap {
     }
 
     // @ts-ignore
-    const installed = this.opts.freeze ? this.installer?.installs[parentPkgUrl]?.[pkgName] : await this.installer?.install(pkgName, parentPkgUrl, subpath === './' ? false : true, parentUrl.href);
+    const installed = this.installer?.installs[parentPkgUrl]?.[pkgName] || !this.opts.freeze && await this.installer?.install(pkgName, parentPkgUrl, subpath === './' ? false : true, parentUrl.href);
     if (installed) {
       let [pkgUrl, subpathBase] = installed.split('|');
       if (subpathBase && !pkgUrl.endsWith('/'))

--- a/test/html/local/react.js
+++ b/test/html/local/react.js
@@ -1,0 +1,1 @@
+export const local = true;

--- a/test/html/maps.test.js
+++ b/test/html/maps.test.js
@@ -1,0 +1,70 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+import { SemverRange } from 'sver';
+
+const generator = new Generator({
+  rootUrl: new URL('./local', import.meta.url),
+  env: ['production', 'browser']
+});
+
+const esmsPkg = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);
+const esmsUrl = generator.traceMap.resolver.pkgToUrl(esmsPkg, generator.traceMap.installer.defaultProvider) + 'dist/es-module-shims.js';
+
+assert.strictEqual(await generator.htmlGenerate(`
+<!doctype html>
+<script type="importmap">
+{
+  "imports": {
+    "object-assign": "/react.js"
+  }
+}
+</script>
+<script type="module">
+  import 'react';
+</script>
+`, { preload: true }), '\n' +
+'<!doctype html>\n' +
+`<script async src="${esmsUrl}" crossorigin="anonymous"></script>\n` +
+'<script type="importmap">\n' +
+'{\n' +
+'  "imports": {\n' +
+'    "object-assign": "/react.js",\n' +
+'    "react": "https://ga.jspm.io/npm:react@17.0.2/index.js"\n' +
+'  }\n' +
+'}\n' +
+'</script>\n' +
+'<link rel="modulepreload" href="https://ga.jspm.io/npm:react@17.0.2/index.js" />\n' +
+'<link rel="modulepreload" href="/react.js" />\n' +
+'<script type="module">\n' +
+"  import 'react';\n" +
+'</script>\n');
+
+// TODO: Fix scope base idempotency
+// Idempotency
+assert.strictEqual(await generator.htmlGenerate('\n' +
+'<!doctype html>\n' +
+`<script async src="${esmsUrl}" crossorigin="anonymous"></script>\n` +
+'<script type="importmap">\n' +
+'{\n' +
+'  "imports": {\n' +
+'    "react": "https://ga.jspm.io/npm:react@17.0.2/index.js"\n' +
+'  },\n' +
+'  "scopes": {\n' +
+'    "https://ga.jspm.io/npm:react@17.0.2/": {\n' +
+'      "object-assign": "https://ga.jspm.io/npm:object-assign@4.1.0/index.js"\n' +
+'    }\n' +
+'  }\n' +
+'}\n' +
+'</script>\n' +
+'<link rel="modulepreload" href="https://ga.jspm.io/npm:react@17.0.1/index.js" />\n' +
+'<link rel="modulepreload" href="/react.js" />\n' +
+'<script type="module">\n' +
+"  import 'react';\n" +
+'</script>\n', { preload: true, whitespace: false }), '\n' +
+'<!doctype html>\n' +
+`<script async src="${esmsUrl}" crossorigin="anonymous"></script>\n` +
+'<script type="importmap">{"imports":{"react":"https://ga.jspm.io/npm:react@17.0.2/index.js"},"scopes":{"https://ga.jspm.io/":{"object-assign":"https://ga.jspm.io/npm:object-assign@4.1.0/index.js"}}}</script>\n' +
+'<link rel="modulepreload" href="https://ga.jspm.io/npm:react@17.0.2/index.js" /><link rel="modulepreload" href="https://ga.jspm.io/npm:object-assign@4.1.0/index.js" />\n' +
+'<script type="module">\n' +
+"  import 'react';\n" +
+'</script>\n');


### PR DESCRIPTION
This adds support for a `generator.getLock()` function for retrieving the lock file from an installer, as well as passing a `lock` option into the installer, resolving https://github.com/jspm/generator/issues/87.

In addition, the `htmlGenerate` method will now infer the lockfile and map as best as possible from the existing import map in the HTML.

The `freeze` and `latest` resolution options can now be passed to the generator initialization to determine how to resolve against the lockfile (don't change the resolutions for freeze, and always seek to use latest resolutions for latest).