### PR TITLE
fix: HTML integrity, URL mappings

### DIFF
--- a/src/common/url.ts
+++ b/src/common/url.ts
@@ -25,6 +25,14 @@ else if (typeof document as any !== 'undefined') {
     baseUrl = new URL('../', new URL(location.href));
 }
 
+export function resolveUrl (url: string, mapUrl: URL, rootUrl: URL) {
+  if (url.startsWith('//'))
+    return new URL(url, rootUrl);
+  if (url.startsWith('/'))
+    return new URL(url.slice(1), rootUrl);
+  return new URL(url, mapUrl);
+}
+
 export function importedFrom (parentUrl?: string | URL) {
   if (!parentUrl) return '';
   return ` imported from ${parentUrl}`;

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,4 +1,4 @@
-import { baseUrl as _baseUrl, isPlain, relativeUrl } from "./common/url.js";
+import { baseUrl as _baseUrl, isPlain, relativeUrl, resolveUrl } from "./common/url.js";
 import { ExactPackage, toPackageTarget } from "./install/package.js";
 import TraceMap from './trace/tracemap.js';
 // @ts-ignore
@@ -490,7 +490,7 @@ export class Generator {
     const analysis = analyzeHtml(html, htmlUrl);
     let preloadDeps: string[] = [];
     const preloadUrls = analysis.preloads.map(preload => preload.attrs.href?.value).filter(x => x);
-    const { maps, lock } = await extractLockAndMap(analysis.map.json || {} as IImportMap, preloadUrls, htmlUrl || this.mapUrl, this.rootUrl, this.traceMap.resolver);
+    const { maps, lock } = await extractLockAndMap(analysis.map.json || {} as IImportMap, preloadUrls, htmlUrl || this.mapUrl, this.rootUrl || this.baseUrl, this.traceMap.resolver);
     for (const pkg of Object.keys(lock)) {
       if (this.traceMap.installer.installs[pkg])
         Object.assign(this.traceMap.installer.installs[pkg] = {}, lock[pkg]);
@@ -500,7 +500,8 @@ export class Generator {
     this.traceMap.map = new ImportMap(this.mapUrl).extend(maps);
     await Promise.all([...new Set([...analysis.staticImports, ...analysis.dynamicImports])].map(async impt => {
       if (isPlain(impt)) {
-        var { staticDeps } = await this.install(impt);
+        const pkgBaseUrl = await this.traceMap.resolver.getPackageBase(this.mapUrl.href);
+        var { staticDeps } = await this.traceInstall(impt, pkgBaseUrl);
       }
       else {
         var { staticDeps } = await this.traceInstall(impt, analysis.base);
@@ -524,7 +525,7 @@ export class Generator {
     let preloads = '';
     if (preload && preloadDeps.length) {
       let first = true;
-      for (let dep of preloadDeps) {
+      for (let dep of preloadDeps.sort()) {
         if (first || whitespace)
           preloads += analysis.map.newlineTab;
         if (first) first = false;
@@ -540,6 +541,19 @@ export class Generator {
     if (preload !== undefined) {
       for (const preload of analysis.preloads) {
         replacer.remove(preload.start, preload.end, true);
+      }
+    }
+
+    // when applying integrity, all existing script tags have their integrity updated
+    if (integrity) {
+      for (const module of analysis.modules) {
+        if (!module.attrs.src)
+          continue;
+        if (module.attrs.integrity) {
+          replacer.remove(module.attrs.integrity.start - (replacer.source[replacer.idx(module.attrs.integrity.start - 1)] === ' ' ? 1 : 0), module.attrs.integrity.end + 1);
+        }
+        const lastAttr = Object.keys(module.attrs).filter(attr => attr !== 'integrity').sort((a, b) => module.attrs[a].end > module.attrs[b].end ? -1 : 1)[0];
+        replacer.replace(module.attrs[lastAttr].end + 1, module.attrs[lastAttr].end + 1, ` integrity="${await getIntegrity(resolveUrl(module.attrs.src.value, this.mapUrl, this.rootUrl).href, this.traceMap.resolver.fetchOpts)}"`)
       }
     }
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -522,6 +522,10 @@ export class Generator {
       replacer.remove(analysis.esModuleShims.start, analysis.esModuleShims.end, true);
     }
 
+    for (const preload of analysis.preloads) {
+      replacer.remove(preload.start, preload.end, true);
+    }
+
     let preloads = '';
     if (preload && preloadDeps.length) {
       let first = true;
@@ -535,12 +539,6 @@ export class Generator {
         else {
           preloads += `<link rel="modulepreload" href="${relativeUrl(new URL(dep), this.rootUrl || this.baseUrl, !!this.rootUrl)}" />`;
         }
-      }
-    }
-
-    if (preload !== undefined) {
-      for (const preload of analysis.preloads) {
-        replacer.remove(preload.start, preload.end, true);
       }
     }
 

--- a/src/html/analyze.ts
+++ b/src/html/analyze.ts
@@ -80,10 +80,13 @@ export function analyzeHtml (source: string, url: URL = baseUrl): HtmlAnalysis {
         else if (type === 'module') {
           const src = getAttr(source, tag, 'src');
           if (src) {
-            if (esmsSrcRegEx.test(src))
+            if (esmsSrcRegEx.test(src)) {
               analysis.esModuleShims = { start: tag.start, end: tag.end, attrs: toHtmlAttrs(source, tag.attributes) };
-            else
+            }
+            else {
               analysis.staticImports.add(isPlain(src) ? './' + src : src);
+              analysis.modules.push({ start: tag.start, end: tag.end, attrs: toHtmlAttrs(source, tag.attributes) });
+            }
           }
           else {
             const [imports] = parse(source.slice(tag.innerStart, tag.innerEnd)) || [];
@@ -96,10 +99,9 @@ export function analyzeHtml (source: string, url: URL = baseUrl): HtmlAnalysis {
         else if (!type || type === 'javascript') {
           const src = getAttr(source, tag, 'src');
           if (src) {
-            if (esmsSrcRegEx.test(src))
+            if (esmsSrcRegEx.test(src)) {
               analysis.esModuleShims = { start: tag.start, end: tag.end, attrs: toHtmlAttrs(source, tag.attributes) };
-            else
-              analysis.staticImports.add(src);
+            }
           }
           else {
             const [imports] = parse(source.slice(tag.innerStart, tag.innerEnd)) || [];

--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -98,6 +98,7 @@ export class Resolver {
           case 200:
           case 304:
             break;
+          case 400:
           case 401:
           case 403:
           case 404:

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -241,7 +241,11 @@ export default class TraceMap {
       const resolvedHref = resolvedUrl.href;
       let finalized = await this.resolver.realPath(await this.resolver.finalizeResolve(resolvedHref, parentIsCjs, env, this.installer, parentPkgUrl));
       // handle URL mappings
-      finalized = this.map.resolve(resolvedUrl.href, parentUrl, env) as string;
+      const urlResolved = this.map.resolve(finalized, parentUrl, env) as string;
+      // TODO: avoid this hack - perhaps solved by conditional maps
+      if (urlResolved !== finalized && !urlResolved.startsWith('node:')) {
+        finalized = urlResolved;
+      }
       if (finalized !== resolvedHref) {
         this.map.set(resolvedHref.endsWith('/') ? resolvedHref.slice(0, -1) : resolvedHref, finalized, parentPkgUrl);
         resolvedUrl = new URL(finalized);

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -239,7 +239,9 @@ export default class TraceMap {
       if (resolvedUrl.protocol !== 'file:' && resolvedUrl.protocol !== 'https:' && resolvedUrl.protocol !== 'http:' && resolvedUrl.protocol !== 'node:' && resolvedUrl.protocol !== 'data:')
         throw new JspmError(`Found unexpected protocol ${resolvedUrl.protocol}${importedFrom(parentUrl)}`);
       const resolvedHref = resolvedUrl.href;
-      const finalized = await this.resolver.realPath(await this.resolver.finalizeResolve(resolvedHref, parentIsCjs, env, this.installer, parentPkgUrl));
+      let finalized = await this.resolver.realPath(await this.resolver.finalizeResolve(resolvedHref, parentIsCjs, env, this.installer, parentPkgUrl));
+      // handle URL mappings
+      finalized = this.map.resolve(resolvedUrl.href, parentUrl, env) as string;
       if (finalized !== resolvedHref) {
         this.map.set(resolvedHref.endsWith('/') ? resolvedHref.slice(0, -1) : resolvedHref, finalized, parentPkgUrl);
         resolvedUrl = new URL(finalized);

--- a/test/html/inject.test.js
+++ b/test/html/inject.test.js
@@ -21,7 +21,7 @@ assert.strictEqual(await generator.htmlGenerate(`
 '<script type="importmap">\n' +
 '{\n' +
 '  "imports": {\n' +
-'    "react": "https://ga.jspm.io/npm:react@17.0.2/index.js"\n' +
+'    "react": "https://ga.jspm.io/npm:react@16.14.0/index.js"\n' +
 '  },\n' +
 '  "scopes": {\n' +
 '    "https://ga.jspm.io/": {\n' +

--- a/test/html/maps.test.js
+++ b/test/html/maps.test.js
@@ -33,38 +33,45 @@ assert.strictEqual(await generator.htmlGenerate(`
 '  }\n' +
 '}\n' +
 '</script>\n' +
-'<link rel="modulepreload" href="https://ga.jspm.io/npm:react@17.0.2/index.js" />\n' +
 '<link rel="modulepreload" href="/react.js" />\n' +
+'<link rel="modulepreload" href="https://ga.jspm.io/npm:react@17.0.2/index.js" />\n' +
 '<script type="module">\n' +
 "  import 'react';\n" +
 '</script>\n');
 
-// TODO: Fix scope base idempotency
-// Idempotency
-assert.strictEqual(await generator.htmlGenerate('\n' +
-'<!doctype html>\n' +
-`<script async src="${esmsUrl}" crossorigin="anonymous"></script>\n` +
-'<script type="importmap">\n' +
-'{\n' +
-'  "imports": {\n' +
-'    "react": "https://ga.jspm.io/npm:react@17.0.2/index.js"\n' +
-'  },\n' +
-'  "scopes": {\n' +
-'    "https://ga.jspm.io/npm:react@17.0.2/": {\n' +
-'      "object-assign": "https://ga.jspm.io/npm:object-assign@4.1.0/index.js"\n' +
-'    }\n' +
-'  }\n' +
-'}\n' +
-'</script>\n' +
-'<link rel="modulepreload" href="https://ga.jspm.io/npm:react@17.0.1/index.js" />\n' +
-'<link rel="modulepreload" href="/react.js" />\n' +
-'<script type="module">\n' +
-"  import 'react';\n" +
-'</script>\n', { preload: true, whitespace: false }), '\n' +
-'<!doctype html>\n' +
-`<script async src="${esmsUrl}" crossorigin="anonymous"></script>\n` +
-'<script type="importmap">{"imports":{"react":"https://ga.jspm.io/npm:react@17.0.2/index.js"},"scopes":{"https://ga.jspm.io/":{"object-assign":"https://ga.jspm.io/npm:object-assign@4.1.0/index.js"}}}</script>\n' +
-'<link rel="modulepreload" href="https://ga.jspm.io/npm:react@17.0.2/index.js" /><link rel="modulepreload" href="https://ga.jspm.io/npm:object-assign@4.1.0/index.js" />\n' +
-'<script type="module">\n' +
-"  import 'react';\n" +
-'</script>\n');
+{
+  const generator = new Generator({
+    rootUrl: new URL('./local', import.meta.url),
+    env: ['production', 'browser']
+  });
+
+  // TODO: Fix scope base idempotency
+  // Idempotency
+  assert.strictEqual(await generator.htmlGenerate('\n' +
+  '<!doctype html>\n' +
+  `<script async src="${esmsUrl}" crossorigin="anonymous"></script>\n` +
+  '<script type="importmap">\n' +
+  '{\n' +
+  '  "imports": {\n' +
+  '    "react": "https://ga.jspm.io/npm:react@17.0.2/index.js"\n' +
+  '  },\n' +
+  '  "scopes": {\n' +
+  '    "https://ga.jspm.io/npm:react@17.0.2/": {\n' +
+  '      "object-assign": "https://ga.jspm.io/npm:object-assign@4.1.0/index.js"\n' +
+  '    }\n' +
+  '  }\n' +
+  '}\n' +
+  '</script>\n' +
+  '<link rel="modulepreload" href="https://ga.jspm.io/npm:react@17.0.1/index.js" />\n' +
+  '<link rel="modulepreload" href="/react.js" />\n' +
+  '<script type="module">\n' +
+  "  import 'react';\n" +
+  '</script>\n', { preload: true, whitespace: false }), '\n' +
+  '<!doctype html>\n' +
+  `<script async src="${esmsUrl}" crossorigin="anonymous"></script>\n` +
+  '<script type="importmap">{"imports":{"react":"https://ga.jspm.io/npm:react@17.0.2/index.js"},"scopes":{"https://ga.jspm.io/":{"object-assign":"https://ga.jspm.io/npm:object-assign@4.1.0/index.js"}}}</script>\n' +
+  '<link rel="modulepreload" href="https://ga.jspm.io/npm:object-assign@4.1.0/index.js" /><link rel="modulepreload" href="https://ga.jspm.io/npm:react@17.0.2/index.js" />\n' +
+  '<script type="module">\n' +
+  "  import 'react';\n" +
+  '</script>\n');
+}

--- a/test/html/preload.test.js
+++ b/test/html/preload.test.js
@@ -23,7 +23,7 @@ assert.strictEqual(await generator.htmlGenerate(`
 '<script type="importmap">\n' +
 '{\n' +
 '  "imports": {\n' +
-'    "react": "https://ga.jspm.io/npm:react@17.0.2/index.js"\n' +
+'    "react": "https://ga.jspm.io/npm:react@16.14.0/index.js"\n' +
 '  },\n' +
 '  "scopes": {\n' +
 '    "https://ga.jspm.io/": {\n' +
@@ -32,8 +32,9 @@ assert.strictEqual(await generator.htmlGenerate(`
 '  }\n' +
 '}\n' +
 '</script>\n' +
-'<link rel="modulepreload" href="https://ga.jspm.io/npm:react@17.0.2/index.js" integrity="sha384-XapV4O3iObT3IDFIFYCLWwO8NSi+SIOMlAWsO3n8+HsPNzAitpl3cdFHbe+msAQY" />\n' +
 '<link rel="modulepreload" href="https://ga.jspm.io/npm:object-assign@4.1.1/index.js" integrity="sha384-iQp1zoaqIhfUYyYkz3UNk1QeFfmBGgt1Ojq0kZD5Prql1g7fgJVzVgsjDoR65lv8" />\n' +
+'<link rel="modulepreload" href="https://ga.jspm.io/npm:react@16.14.0/cjs/react.production.min.js" integrity="sha384-pTMZhybzHZ+1G029kWUmoGvTrBp1C+2oJAkZV48BBq7+e6Hk3bGuXtvxT2vQfBqj" />\n' +
+'<link rel="modulepreload" href="https://ga.jspm.io/npm:react@16.14.0/index.js" integrity="sha384-jVagjV+2YtlseazU2byX6gMLPHaA5Ps2c6HhvsGDlWjn45YCCoU1q+QtQTOb1MjT" />\n' +
 '<script type="module">\n' +
 "  import 'react';\n" +
 '</script>\n');
@@ -45,7 +46,7 @@ assert.strictEqual(await generator.htmlGenerate('\n' +
 '<script type="importmap">\n' +
 '{\n' +
 '  "imports": {\n' +
-'    "react": "https://ga.jspm.io/npm:react@17.0.2/index.js"\n' +
+'    "react": "https://ga.jspm.io/npm:react@16.14.0/index.js"\n' +
 '  },\n' +
 '  "scopes": {\n' +
 '    "https://ga.jspm.io/": {\n' +
@@ -54,16 +55,16 @@ assert.strictEqual(await generator.htmlGenerate('\n' +
 '  }\n' +
 '}\n' +
 '</script>\n' +
-'<link rel="modulepreload" href="https://ga.jspm.io/npm:react@17.0.2/index.js" integrity="sha384-XapV4O3iObT3IDFIFYCLWwO8NSi+SIOMlAWsO3n8+HsPNzAitpl3cdFHbe+msAQY" />\n' +
 '<link rel="modulepreload" href="https://ga.jspm.io/npm:object-assign@4.1.1/index.js" integrity="sha384-iQp1zoaqIhfUYyYkz3UNk1QeFfmBGgt1Ojq0kZD5Prql1g7fgJVzVgsjDoR65lv8" />\n' +
-'<link rel="modulepreload" href="https://ga.jspm.io/npm:react@17.0.2/cjs/react.production.min.js" integrity="sha384-vXMyhkZyH+f511olSQcszeIja6v6wqVgCllFQ5yk4qCDfVRzDEHt90aYx9e6V1KL" />\n' +
+'<link rel="modulepreload" href="https://ga.jspm.io/npm:react@16.14.0/index.js" integrity="sha384-XapV4O3iObT3IDFIFYCLWwO8NSi+SIOMlAWsO3n8+HsPNzAitpl3cdFHbe+msAQY" />\n' +
+'<link rel="modulepreload" href="https://ga.jspm.io/npm:react@16.14.0/cjs/react.production.min.js" integrity="sha384-vXMyhkZyH+f511olSQcszeIja6v6wqVgCllFQ5yk4qCDfVRzDEHt90aYx9e6V1KL" />\n' +
 '<script type="module">\n' +
 "  import 'react';\n" +
 '</script>\n', { preload: true, integrity: true, whitespace: false }), '\n' +
 '<!doctype html>\n' +
 `<script async src="${esmsUrl}" crossorigin="anonymous" integrity="${esmsIntegrity}"></script>\n` +
-'<script type="importmap">{"imports":{"react":"https://ga.jspm.io/npm:react@17.0.2/index.js"},"scopes":{"https://ga.jspm.io/":{"object-assign":"https://ga.jspm.io/npm:object-assign@4.1.1/index.js"}}}</script>\n' +
-'<link rel="modulepreload" href="https://ga.jspm.io/npm:react@17.0.2/index.js" integrity="sha384-XapV4O3iObT3IDFIFYCLWwO8NSi+SIOMlAWsO3n8+HsPNzAitpl3cdFHbe+msAQY" /><link rel="modulepreload" href="https://ga.jspm.io/npm:object-assign@4.1.1/index.js" integrity="sha384-iQp1zoaqIhfUYyYkz3UNk1QeFfmBGgt1Ojq0kZD5Prql1g7fgJVzVgsjDoR65lv8" />\n' +
+'<script type="importmap">{"imports":{"react":"https://ga.jspm.io/npm:react@16.14.0/index.js"},"scopes":{"https://ga.jspm.io/":{"object-assign":"https://ga.jspm.io/npm:object-assign@4.1.1/index.js"}}}</script>\n' +
+'<link rel="modulepreload" href="https://ga.jspm.io/npm:object-assign@4.1.1/index.js" integrity="sha384-iQp1zoaqIhfUYyYkz3UNk1QeFfmBGgt1Ojq0kZD5Prql1g7fgJVzVgsjDoR65lv8" /><link rel="modulepreload" href="https://ga.jspm.io/npm:react@16.14.0/cjs/react.production.min.js" integrity="sha384-pTMZhybzHZ+1G029kWUmoGvTrBp1C+2oJAkZV48BBq7+e6Hk3bGuXtvxT2vQfBqj" /><link rel="modulepreload" href="https://ga.jspm.io/npm:react@16.14.0/index.js" integrity="sha384-jVagjV+2YtlseazU2byX6gMLPHaA5Ps2c6HhvsGDlWjn45YCCoU1q+QtQTOb1MjT" />\n' +
 '<script type="module">\n' +
 "  import 'react';\n" +
 '</script>\n');


### PR DESCRIPTION
This fixes HTML integrity injection for all module scripts when using `integrity: true` for `htmlGenerate`, ensuring the integrity is comprehensively supported.

It also resolves https://github.com/jspm/generator/issues/105 in supporting local `inputMap` URL mappings.