### PR TITLE
fix: types field

### DIFF
--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Package Import Map Generation Tool",
   "license": "MIT",
   "version": "1.0.0-beta.29",
-  "types": "lib/generator.d.ts",
+  "types": "src/generator.ts",
   "type": "module",
   "scripts": {
     "prepublishOnly": "chomp build"


### PR DESCRIPTION
The TypeScript `"types"` field fell out of sync, this updates to the new build structure.