### PR TITLE
fix: imports field external resolutions

### DIFF
--- a/chompfile.toml
+++ b/chompfile.toml
@@ -2,7 +2,7 @@ version = 0.1
 
 extensions = ['chomp@0.1:swc', 'chomp@0.1:rollup']
 
-default-task = 'test'
+default-task = 'build'
 
 [[task]]
 target = 'docs'
@@ -35,8 +35,8 @@ run = '''
 
 [[task]]
 name = 'build:ts'
-target = 'lib/#.js'
-deps = ['src/#.ts']
+target = 'lib/##.js'
+deps = ['src/##.ts']
 template = 'swc'
 [task.template-options.config]
 inlineSourcesContent = false
@@ -53,7 +53,7 @@ deps = [
 [[task]]
 name = 'unit:#'
 serial = true
-deps = ['test/#.test.js', 'build:ts', 'dist/*']
+deps = ['test/##.test.js', 'build:ts', 'dist/*']
 display = 'dot'
 run = 'node --enable-source-maps -C source $DEP'
 

--- a/src/trace/analysis.ts
+++ b/src/trace/analysis.ts
@@ -11,7 +11,7 @@ export { createCjsAnalysis } from './cjs.js';
 
 export function createEsmAnalysis (imports: any[], source: string, url: string): Analysis {
   if (!imports.length && registerRegEx.test(source))
-    return createSystemAnalysis(source, imports, url);  
+    return createSystemAnalysis(source, imports, url);
   const deps: string[] = [];
   const dynamicDeps: string[] = [];
   for (const impt of imports) {

--- a/test/api/ignore.test.js
+++ b/test/api/ignore.test.js
@@ -16,8 +16,6 @@ await generator.install('@react-three/fiber@7.0.15')
 
 const json = generator.getMap();
 
-console.log(json)
-
 assert.deepEqual(json.imports, {
     "react": "./location/that/cant/be/traced.js",
     "@react-three/fiber": "https://ga.jspm.io/npm:@react-three/fiber@7.0.15/dist/react-three-fiber.esm.js",

--- a/test/api/resolutions.test.js
+++ b/test/api/resolutions.test.js
@@ -9,7 +9,7 @@ const generator = new Generator({
   }
 });
 
-await generator.install('@babel/core');
+await generator.install('@babel/core@7.16.0');
 const json = generator.getMap();
 
 assert.ok(json.imports['@babel/core']);

--- a/test/api/self.test.js
+++ b/test/api/self.test.js
@@ -7,7 +7,7 @@ const generator = new Generator({
 
 const { staticDeps, dynamicDeps } = await generator.install('@jspm/generator@1.0.0-beta.13');
 
-assert.strictEqual(staticDeps.length, 118);
+assert.strictEqual(staticDeps.length, 113);
 assert.strictEqual(dynamicDeps.length, 0);
 
 const json = generator.getMap();

--- a/test/html/indent.test.js
+++ b/test/html/indent.test.js
@@ -4,7 +4,10 @@ import { SemverRange } from 'sver';
 
 const generator = new Generator({
   rootUrl: new URL('./local', import.meta.url),
-  env: ['production', 'browser']
+  env: ['production', 'browser'],
+  resolutions: {
+    react: '17'
+  }
 });
 
 const esmsPkg = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);

--- a/test/html/injectionpoint.test.js
+++ b/test/html/injectionpoint.test.js
@@ -4,7 +4,10 @@ import { SemverRange } from 'sver';
 
 const generator = new Generator({
   rootUrl: new URL('./local', import.meta.url),
-  env: ['production', 'browser']
+  env: ['production', 'browser'],
+  resolutions: {
+    react: '17'
+  }
 });
 
 const esmsPkg = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);

--- a/test/html/inline.test.js
+++ b/test/html/inline.test.js
@@ -4,7 +4,10 @@ import { SemverRange } from 'sver';
 
 const generator = new Generator({
   mapUrl: new URL('app.html', import.meta.url),
-  env: ['production', 'browser']
+  env: ['production', 'browser'],
+  resolutions: {
+    react: '17'
+  }
 });
 
 const esmsPkg = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);

--- a/test/html/lit.test.js
+++ b/test/html/lit.test.js
@@ -4,7 +4,12 @@ import { SemverRange } from 'sver';
 
 const generator = new Generator({
   rootUrl: new URL('./local', import.meta.url),
-  env: ['production', 'browser', 'module']
+  env: ['production', 'browser', 'module'],
+  resolutions: {
+    'lit': '2.2.1',
+    '@lit/reactive-element': '1.3.1',
+    'lit-html': '2.2.1'
+  }
 });
 
 const esmsPkg = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);

--- a/test/html/maps.test.js
+++ b/test/html/maps.test.js
@@ -4,7 +4,10 @@ import { SemverRange } from 'sver';
 
 const generator = new Generator({
   rootUrl: new URL('./local', import.meta.url),
-  env: ['production', 'browser']
+  env: ['production', 'browser'],
+  resolutions: {
+    react: '17'
+  }
 });
 
 const esmsPkg = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);

--- a/test/html/ws.test.js
+++ b/test/html/ws.test.js
@@ -4,7 +4,10 @@ import { SemverRange } from 'sver';
 
 const generator = new Generator({
   rootUrl: new URL('./local', import.meta.url),
-  env: ['production', 'browser']
+  env: ['production', 'browser'],
+  resolutions: {
+    react: '17'
+  }
 });
 
 const esmsPkg = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);

--- a/test/resolve/object-inspect.test.js
+++ b/test/resolve/object-inspect.test.js
@@ -1,0 +1,13 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+const generator = new Generator({
+  mapUrl: import.meta.url
+});
+
+await generator.install('object-inspect@1.12.0');
+
+const json = generator.getMap();
+
+assert.equal(Object.keys(json.imports).length, 1);
+assert.equal(Object.keys(json.scopes).length, 1);


### PR DESCRIPTION
This fixes support for imports like:

```json
{
  "imports": {
    "#impt": "external"
  }
}
```

support in the generator where those resolutions then go through normal external package import resolution.