### PR TITLE
Deno provider

### DIFF
--- a/src/common/fetch-native.ts
+++ b/src/common/fetch-native.ts
@@ -18,6 +18,24 @@ export async function fetch (url, opts) {
   try {
     return await globalThis.fetch(url, opts);
   }
+  catch (e) {
+    // CORS errors throw a fetch type error
+    // Instead, treat this as an actual unauthorized response
+    if (e instanceof TypeError) {
+      return {
+        status: 401,
+        async text () {
+          return '';
+        },
+        async json () {
+          throw new Error('Not JSON');
+        },
+        arrayBuffer () {
+          return new ArrayBuffer(0);
+        }
+      };
+    }
+  }
   finally {
     popFetchPool();
   }

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -232,8 +232,12 @@ export class Installer {
       }
     }
 
-    if (this.resolutions[pkgName])
-      return this.installTarget(pkgName, newPackageTarget(this.resolutions[pkgName], this.opts.baseUrl.href, pkgName), mode, pkgScope, pjsonPersist, subpath, parentUrl);
+    // resolutions are authoritative at the top-level
+    if (this.resolutions[pkgName]) {
+      const resolutionTarget = newPackageTarget(this.resolutions[pkgName], this.opts.baseUrl.href, pkgName);
+      if (JSON.stringify(target) !== JSON.stringify(resolutionTarget))
+        return this.installTarget(pkgName, resolutionTarget, mode, pkgScope, pjsonPersist, subpath, parentUrl);
+    }
 
     const latest = await this.resolver.resolveLatestTarget(target, false, provider, parentUrl);
     const installed = getInstalledRanges(this.installedRanges, target);

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -232,6 +232,9 @@ export class Installer {
       }
     }
 
+    if (this.resolutions[pkgName])
+      return this.installTarget(pkgName, newPackageTarget(this.resolutions[pkgName], this.opts.baseUrl.href, pkgName), mode, pkgScope, pjsonPersist, subpath, parentUrl);
+
     const latest = await this.resolver.resolveLatestTarget(target, false, provider, parentUrl);
     const installed = getInstalledRanges(this.installedRanges, target);
     const restrictedToPkg = this.tryUpgradePackagesTo(latest, target, installed, provider);

--- a/src/providers/denoland.ts
+++ b/src/providers/denoland.ts
@@ -1,0 +1,37 @@
+import { ExactPackage, LatestPackageTarget } from "../install/package.js";
+import { Resolver } from "../trace/resolver.js";
+// @ts-ignore
+import { fetch } from '#fetch';
+
+const cdnUrl = 'https://deno.land/x/';
+
+export function pkgToUrl (pkg: ExactPackage) {
+  return cdnUrl + pkg.name + '@v' + pkg.version + '/';
+}
+
+export function parseUrlPkg (url: string): ExactPackage | undefined {
+  if (!url.startsWith(cdnUrl))
+    return;
+  const path = url.slice(cdnUrl.length);
+  const versionIndex = path.indexOf('@v');
+  if (versionIndex === -1)
+    return;
+  const sepIndex = path.indexOf('/', versionIndex);
+  return { registry: 'deno', name: path.slice(0, versionIndex), version: path.slice(versionIndex + 2, sepIndex === -1 ? path.length : sepIndex) };
+}
+
+export async function resolveLatestTarget (this: Resolver, target: LatestPackageTarget, unstable: boolean, _layer: string, parentUrl: string): Promise<ExactPackage | null> {
+  const { registry, name, range } = target;
+
+  if (range.isExact)
+    return { registry, name, version: range.version.toString() };
+
+  if (!range.isWildcard)
+    throw new Error(`Version ranges are not supported looking up in the Deno registry currently, until an API is available.`);
+
+  const fetchOpts = { ...this.fetchOpts, headers: Object.assign({}, this.fetchOpts.headers || {}, { 'accept': 'text/html' }) };
+  const res = await fetch(cdnUrl + name, fetchOpts);
+  if (!res.ok)
+    throw new Error(`Deno: Unable to lookup ${cdnUrl + name}`);
+  return parseUrlPkg(res.url);
+}

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,3 +1,4 @@
+import * as deno from './denoland.js';
 import * as jspm from './jspm.js';
 import * as skypack from './skypack.js';
 import * as jsdelivr from './jsdelivr.js';
@@ -17,6 +18,7 @@ export interface Provider {
 }
 
 export const defaultProviders: Record<string, Provider> = {
+  deno,
   jsdelivr,
   jspm,
   node,

--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -633,6 +633,8 @@ async function legacyMainResolve (this: Resolver, main: string | null, pkgUrl: U
       return guess;
   }
   else {
+    if (pkgUrl.protocol !== 'file:' && await this.exists(guess = new URL('./mod.ts', pkgUrl).href))
+      return guess;
     if (await this.exists(guess = new URL('./index.js', pkgUrl).href))
       return guess;
     if (await this.exists(guess = new URL('./index.json', pkgUrl).href))

--- a/test/providers/deno.test.js
+++ b/test/providers/deno.test.js
@@ -6,8 +6,8 @@ const generator = new Generator({
   defaultProvider: 'deno'
 });
 
-await generator.install('oak');
+await generator.install('oak@10.6.0');
 
 const json = generator.getMap();
 
-console.log(json);
+assert.strictEqual(json.imports['oak'], 'https://deno.land/x/oak@v10.6.0/mod.ts');

--- a/test/providers/deno.test.js
+++ b/test/providers/deno.test.js
@@ -1,0 +1,13 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+const generator = new Generator({
+  mapUrl: new URL('../../', import.meta.url),
+  defaultProvider: 'deno'
+});
+
+await generator.install('oak');
+
+const json = generator.getMap();
+
+console.log(json);


### PR DESCRIPTION
This adds a Deno provider with very basic lookup support and package parsing. In addition a browser fix for the CORS error on Deno not founds is added as well.

Resolves https://github.com/jspm/generator/issues/138.