### PR TITLE
feat: reinstall method, fix destructuring case

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
         "@babel/plugin-syntax-import-assertions": "^7.17.12",
         "@babel/preset-typescript": "^7.17.2",
         "@jspm/core": "^2.0.0-beta.8",
-        "@jspm/import-map": "^0.3.1",
+        "@jspm/import-map": "^1.0.4",
         "es-module-lexer": "^0.10.4",
         "ipfs-client": "^0.7.1",
         "make-fetch-happen": "^8.0.3",
@@ -592,9 +592,9 @@
       "integrity": "sha512-eFbitkdFBKl10pKdBENW+gCRz/tMfkthFfNP9VYoqaeEmets0Ysb8eFz/SGOogzi5yi50eRjwXVqL3VVAQ6jYA=="
     },
     "node_modules/@jspm/import-map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jspm/import-map/-/import-map-0.3.3.tgz",
-      "integrity": "sha512-hD9CIedeViPfUHEs8mmjzAhr/WXR+tsjfC+Evq6GAJMB3wxlW4amUNGgpwRNqfSvd2izA+ekxW9X5FFAJJKJEQ=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jspm/import-map/-/import-map-1.0.4.tgz",
+      "integrity": "sha512-4ykMZnJPUf+JV1yF+XWOBPEGzqKzrTKhKRskWNCcTf4vSBZnPn7hAch6X4/0DtC42ryOza7Mky5QmtQzxPFvaw=="
     },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
@@ -4077,9 +4077,9 @@
       "integrity": "sha512-eFbitkdFBKl10pKdBENW+gCRz/tMfkthFfNP9VYoqaeEmets0Ysb8eFz/SGOogzi5yi50eRjwXVqL3VVAQ6jYA=="
     },
     "@jspm/import-map": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/@jspm/import-map/-/import-map-0.3.3.tgz",
-      "integrity": "sha512-hD9CIedeViPfUHEs8mmjzAhr/WXR+tsjfC+Evq6GAJMB3wxlW4amUNGgpwRNqfSvd2izA+ekxW9X5FFAJJKJEQ=="
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/@jspm/import-map/-/import-map-1.0.4.tgz",
+      "integrity": "sha512-4ykMZnJPUf+JV1yF+XWOBPEGzqKzrTKhKRskWNCcTf4vSBZnPn7hAch6X4/0DtC42ryOza7Mky5QmtQzxPFvaw=="
     },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jspm/generator",
-  "version": "1.0.0-beta.32",
+  "version": "1.0.0-beta.33",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "@jspm/generator",
-      "version": "1.0.0-beta.32",
+      "version": "1.0.0-beta.33",
       "license": "MIT",
       "dependencies": {
         "@babel/core": "^7.18.2",

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "@babel/plugin-syntax-import-assertions": "^7.17.12",
     "@babel/preset-typescript": "^7.17.2",
     "@jspm/core": "^2.0.0-beta.8",
-    "@jspm/import-map": "^0.3.1",
+    "@jspm/import-map": "^1.0.4",
     "es-module-lexer": "^0.10.4",
     "ipfs-client": "^0.7.1",
     "make-fetch-happen": "^8.0.3",

--- a/src/common/url.ts
+++ b/src/common/url.ts
@@ -25,12 +25,10 @@ else if (typeof document as any !== 'undefined') {
     baseUrl = new URL('../', new URL(location.href));
 }
 
-export function resolveUrl (url: string, mapUrl: URL, rootUrl: URL) {
-  if (url.startsWith('//'))
-    return new URL(url, rootUrl);
+export function resolveUrl (url: string, mapUrl: URL, rootUrl: URL | null): string {
   if (url.startsWith('/'))
-    return new URL(url.slice(1), rootUrl);
-  return new URL(url, mapUrl);
+    return rootUrl ? new URL('.' + url.slice(url[1] === '/' ? 1 : 0), rootUrl).href : url;
+  return new URL(url, mapUrl).href;
 }
 
 export function importedFrom (parentUrl?: string | URL) {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -12,7 +12,7 @@ import { analyzeHtml } from "./html/analyze.js";
 import { SemverRange } from 'sver';
 import { Replacer } from "./common/str.js";
 import { getIntegrity } from "./common/integrity.js";
-import { extractLockAndMap, LockResolutions, normalizeLock, resolveLock } from "./install/lock.js";
+import { extractLockAndMap, LockResolutions, normalizeLock } from "./install/lock.js";
 
 export { analyzeHtml }
 
@@ -50,7 +50,7 @@ export interface GeneratorOptions {
    * E.g. for `rootUrl: 'file:///path/to/project/public'`, any local module `public/local/mod.js` within the `public` folder
    * will be normalized to `/local/mod.js` in the output map.
    */
-  rootUrl?: URL | string;
+  rootUrl?: URL | string | null;
   /**
    * An authoritative initial import map.
    * 
@@ -384,9 +384,10 @@ export class Generator {
         this.mapUrl = new URL(this.mapUrl.href + '/');
       }
     }
-    this.traceMap = new TraceMap(this.mapUrl, {
+    this.traceMap = new TraceMap({
+      mapUrl: this.mapUrl,
       lock,
-      rootUrl: this.rootUrl || this.baseUrl,
+      rootUrl: this.rootUrl,
       baseUrl: this.baseUrl,
       stdlib,
       env,
@@ -398,7 +399,7 @@ export class Generator {
       freeze,
       latest
     }, log, resolver);
-    this.map = new ImportMap(this.mapUrl);
+    this.map = new ImportMap({ mapUrl: this.mapUrl, rootUrl: this.rootUrl });
     if (inputMap)
       this.map.extend(inputMap);
   }
@@ -570,7 +571,7 @@ export class Generator {
           replacer.remove(module.attrs.integrity.start - (replacer.source[replacer.idx(module.attrs.integrity.start - 1)] === ' ' ? 1 : 0), module.attrs.integrity.end + 1);
         }
         const lastAttr = Object.keys(module.attrs).filter(attr => attr !== 'integrity').sort((a, b) => module.attrs[a].end > module.attrs[b].end ? -1 : 1)[0];
-        replacer.replace(module.attrs[lastAttr].end + 1, module.attrs[lastAttr].end + 1, ` integrity="${await getIntegrity(resolveUrl(module.attrs.src.value, this.mapUrl, this.rootUrl).href, this.traceMap.resolver.fetchOpts)}"`)
+        replacer.replace(module.attrs[lastAttr].end + 1, module.attrs[lastAttr].end + 1, ` integrity="${await getIntegrity(resolveUrl(module.attrs.src.value, this.mapUrl, this.rootUrl), this.traceMap.resolver.fetchOpts)}"`)
       }
     }
 
@@ -705,9 +706,7 @@ export class Generator {
     if (--this.installCnt !== 0)
       throw new JspmError(`Another install was started during extract map.`);
     const { map, staticDeps, dynamicDeps } = await this.traceMap.finishInstall(names);
-    map.flatten(this.rootUrl ? this.rootUrl : this.baseUrl);
-    if (this.rootUrl)
-      map.rebase(this.rootUrl.href, true);
+    map.flatten();
     map.sort();
     return { map: map.toJSON(), staticDeps, dynamicDeps };
   }
@@ -756,10 +755,9 @@ export class Generator {
 
   getMap () {
     const map = this.map.clone();
-    map.flatten(this.rootUrl ? this.rootUrl : this.baseUrl);
-    if (this.rootUrl)
-      map.rebase(this.rootUrl.href, true);
+    map.flatten();
     map.sort();
+    map.rebase();
     return map.toJSON();
   }
 }

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -44,10 +44,12 @@ function getInstalledRanges (installedRanges: InstalledRanges, target: PackageTa
 }
 
 export interface InstallOptions {
+  // import map URL
+  mapUrl: URL;
   // default base for relative installs
   baseUrl: URL;
   // root URL for inport map root resolution
-  rootUrl: URL;
+  rootUrl?: URL | null;
   // create a lockfile if it does not exist
   lock?: LockResolutions;
   // do not modify the lockfile

--- a/src/install/lock.ts
+++ b/src/install/lock.ts
@@ -67,48 +67,49 @@ export function setResolution (resolutions: LockResolutions, name: string, pkgUr
   return true;
 }
 
-export async function extractLockAndMap (map: IImportMap, preloadUrls: string[], mapUrl: URL, rootUrl: URL, resolver: Resolver): Promise<{ lock: LockResolutions, maps: IImportMap }> {
+export async function extractLockAndMap (map: IImportMap, preloadUrls: string[], mapUrl: URL, rootUrl: URL | null, resolver: Resolver): Promise<{ lock: LockResolutions, maps: IImportMap }> {
   const lock: LockResolutions = {};
   const maps: IImportMap = { imports: Object.create(null), scopes: Object.create(null) };
 
   const mapBase = await resolver.getPackageBase(mapUrl.href);
 
   for (const key of Object.keys(map.imports || {})) {
-    const targetUrl = resolveUrl(map.imports[key], mapUrl, rootUrl).href;
-    const providerPkg = resolver.parseUrlPkg(targetUrl);
-    const resolvedKey = isPlain(key) ? key : resolveUrl(key, mapUrl, rootUrl).href;
-    const pkgUrl = providerPkg ? resolver.pkgToUrl(providerPkg.pkg, providerPkg.source) : await getPackageBase(targetUrl);
-    const parsed = isPlain(key) ? parsePkg(key) : null;
-    if (parsed && await resolver.hasExportResolution(pkgUrl, parsed.subpath, targetUrl, key)) {
-      // TODO: lockfile should really now be based on primary and scoped
-      if (key[0] !== '#') {
-        setResolution(lock, resolvedKey, mapBase, pkgUrl, '');
-      }
-    }
-    else {
-      maps.imports[resolvedKey] = targetUrl;
-    }
-  }
-
-  for (const scopeUrl of Object.keys(map.scopes || {})) {
-    const resolvedScopeUrl = resolveUrl(scopeUrl, mapUrl, rootUrl).href;
-    const scope = map.scopes[scopeUrl];
-    for (const key of Object.keys(scope)) {
-      const targetUrl = resolveUrl(scope[key], mapUrl, rootUrl).href;
+    const resolvedKey = isPlain(key) ? key : resolveUrl(key, mapUrl, rootUrl);
+    const targetUrl = resolveUrl(map.imports[key], mapUrl, rootUrl);
+    if (targetUrl) {
       const providerPkg = resolver.parseUrlPkg(targetUrl);
-      const resolvedKey = isPlain(key) ? key : resolveUrl(key, mapUrl, rootUrl).href;
       const pkgUrl = providerPkg ? resolver.pkgToUrl(providerPkg.pkg, providerPkg.source) : await getPackageBase(targetUrl);
       const parsed = isPlain(key) ? parsePkg(key) : null;
       if (parsed && await resolver.hasExportResolution(pkgUrl, parsed.subpath, targetUrl, key)) {
+        // TODO: lockfile should really now be based on primary and scoped
         if (key[0] !== '#') {
-          const scopePkgUrl = await resolver.getPackageBase(resolvedScopeUrl);
-          // Should this support the /|nodelibs/process style core syntax?
-          setResolution(lock, resolvedKey, scopePkgUrl, pkgUrl, '');
+          setResolution(lock, resolvedKey, mapBase, pkgUrl, '');
+        }
+        continue;
+      }
+    }
+    maps.imports[resolvedKey] = targetUrl ?? map.imports[key];
+  }
+
+  for (const scopeUrl of Object.keys(map.scopes || {})) {
+    const resolvedScopeUrl = resolveUrl(scopeUrl, mapUrl, rootUrl) ?? scopeUrl;
+    const scope = map.scopes[scopeUrl];
+    for (const key of Object.keys(scope)) {
+      const resolvedKey = isPlain(key) ? key : resolveUrl(key, mapUrl, rootUrl);
+      const targetUrl = resolveUrl(scope[key], mapUrl, rootUrl);
+      if (targetUrl) {
+        const providerPkg = resolver.parseUrlPkg(targetUrl);
+        const pkgUrl = providerPkg ? resolver.pkgToUrl(providerPkg.pkg, providerPkg.source) : await getPackageBase(targetUrl);
+        const parsed = isPlain(key) ? parsePkg(key) : null;
+        if (parsed && await resolver.hasExportResolution(pkgUrl, parsed.subpath, targetUrl, key)) {
+          if (key[0] !== '#') {
+            const scopePkgUrl = await resolver.getPackageBase(resolvedScopeUrl);
+            setResolution(lock, resolvedKey, scopePkgUrl, pkgUrl, '');
+          }
+          continue;
         }
       }
-      else {
-        (maps.scopes[resolvedScopeUrl] = maps.scopes[resolvedScopeUrl] || Object.create(null))[key] = targetUrl;
-      }
+      (maps.scopes[resolvedScopeUrl] = maps.scopes[resolvedScopeUrl] || Object.create(null))[key] = targetUrl;
     }
   }
 

--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -488,7 +488,7 @@ export class Resolver {
   //   }
   // }
 
-  async analyze (resolvedUrl: string, parentUrl: URL, system: boolean, isRequire: boolean, retry = true): Promise<Analysis> {
+  async analyze (resolvedUrl: string, parentUrl: string, system: boolean, isRequire: boolean, retry = true): Promise<Analysis> {
     const res = await fetch(resolvedUrl, this.fetchOpts);
     switch (res.status) {
       case 200:

--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -11,6 +11,7 @@ import { Analysis, createSystemAnalysis, createCjsAnalysis, createEsmAnalysis, c
 // @ts-ignore
 import { getMapMatch } from '@jspm/import-map';
 import { Installer, PackageProvider } from '../install/installer.js';
+import { nodeBuiltinSet } from '../providers/node.js';
 
 let realpath, pathToFileURL;
 
@@ -274,8 +275,26 @@ export class Resolver {
   }
 
   // returns true or false whether this package subpath can resolve to the given target URL for some env value
+  // also handles "imports"
   async hasExportResolution (pkgUrl: string, subpath: string, target: string, originalSpecifier: string): Promise<boolean> {
     const pcfg = await this.getPackageConfig(pkgUrl) || {};
+    if (originalSpecifier[0] === '#') {
+      if (pcfg.imports === undefined || pcfg.imports === null)
+        return false;
+      const match = getMapMatch(originalSpecifier, pcfg.imports as Record<string, ExportsTarget>);
+      if (!match)
+        return false;
+      const targets = enumeratePackageTargets(pcfg.imports[match], pkgUrl, subpath.slice(match.length - (match.endsWith('*') ? 1 : 0)), false);
+      for (const curTarget of targets) {
+        try {
+          if (await this.finalizeResolve(curTarget, false, [], null, pkgUrl) === target) {
+            return true;
+          }
+        }
+        catch {}
+      }
+      return false;
+    }
     if (pcfg.exports !== undefined && pcfg.exports !== null) {
       function allDotKeys (exports: Record<string, any>) {
         for (let p in exports) {
@@ -314,14 +333,20 @@ export class Resolver {
         return false;
       }
       else {
-        const match = getMapMatch(subpath, pcfg.exports as Record<string, ExportsTarget>);
-        if (!match)
-          return false;
+        let match = getMapMatch(subpath, pcfg.exports as Record<string, ExportsTarget>);
+        if (!match) {
+          if (nodeBuiltinSet.has(originalSpecifier)) {
+            match = getMapMatch('./nodelibs/' + originalSpecifier, pcfg.exports as Record<string, ExportsTarget>);
+          }
+          if (!match)
+            return false;
+        }
         const targets = enumeratePackageTargets(pcfg.exports[match], pkgUrl, subpath.slice(match.length - (match.endsWith('*') ? 1 : 0)), false);
         for (const curTarget of targets) {
           try {
-            if (await this.finalizeResolve(curTarget, false, [], null, pkgUrl) === target)
+            if (await this.finalizeResolve(curTarget, false, [], null, pkgUrl) === target) {
               return true;
+            }
           }
           catch {}
         }

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -140,6 +140,8 @@ export default class TraceMap {
 
   async extractMap (pins: string[]) {
     const map = new ImportMap(this.mapBase);
+    // note this plucks custom top-level imports
+    // we may want better control over this
     map.extend(this.inputMap);
     // re-drive all the traces to convergence
     do {

--- a/test/api/devdependencies.test.js
+++ b/test/api/devdependencies.test.js
@@ -9,4 +9,5 @@ const generator = new Generator({
 
 await generator.traceInstall('localpkg/jquery');
 const json = generator.getMap();
+
 assert.ok(json.scopes['./'].jquery.includes('@2'));

--- a/test/api/localcjs.test.js
+++ b/test/api/localcjs.test.js
@@ -13,7 +13,7 @@ if (typeof document === 'undefined') {
   const json = generator.getMap();
 
   assert.strictEqual(json.imports['localpkg/cjs'], './local/pkg/e.cjs');
-  assert.strictEqual(json.scopes['./']['#cjsdep'], './local/pkg/f.cjs');
+  assert.strictEqual(json.scopes['./local/pkg/']['#cjsdep'], './local/pkg/f.cjs');
 
   const meta = generator.getAnalysis(new URL('./local/pkg/f.cjs', import.meta.url));
   assert.deepStrictEqual(meta.cjsLazyDeps, ['./a.js']);

--- a/test/api/localdeps.test.js
+++ b/test/api/localdeps.test.js
@@ -9,5 +9,6 @@ const generator = new Generator({
 
 await generator.install({ target: './local/pkg', subpath: './withdep' });
 const json = generator.getMap();
+
 assert.strictEqual(json.imports['localpkg/withdep'], './local/pkg/b.js');
-assert.strictEqual(json.scopes['./'].dep, './local/dep/main.js');
+assert.strictEqual(json.scopes['./local/pkg/'].dep, './local/dep/main.js');

--- a/test/api/localdepsdirect.test.js
+++ b/test/api/localdepsdirect.test.js
@@ -9,5 +9,6 @@ const generator = new Generator({
 
 await generator.install({ target: './local/pkg', subpath: './withdep2' });
 const json = generator.getMap();
+
 assert.strictEqual(json.imports['localpkg/withdep2'], './local/pkg/c.js');
-assert.strictEqual(json.scopes['./'].dep2, './local/dep/main.js');
+assert.strictEqual(json.scopes['./local/pkg/'].dep2, './local/dep/main.js');

--- a/test/api/localresolutions.test.js
+++ b/test/api/localresolutions.test.js
@@ -13,4 +13,5 @@ const generator = new Generator({
 
 await generator.install({ target: './api/local/pkg', subpath: './withdep' });
 const json = generator.getMap();
-assert.strictEqual(json.scopes['../'].dep, './local/dep/main.js');
+
+assert.strictEqual(json.scopes['./local/pkg/'].dep, './local/dep/main.js');

--- a/test/api/reenv.test.js
+++ b/test/api/reenv.test.js
@@ -1,0 +1,24 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+const generator = new Generator({
+  inputMap: {
+    "imports": {
+      "react": "https://ga.jspm.io/npm:react@17.0.1/dev.index.js"
+    },
+    "scopes": {
+      "https://ga.jspm.io/": {
+        "object-assign": "https://ga.jspm.io/npm:object-assign@4.1.0/index.js"
+      }
+    }
+  },
+  mapUrl: import.meta.url,
+  defaultProvider: 'jspm',
+  env: ['production', 'browser']
+});
+
+await generator.reinstall();
+const json = generator.getMap();
+
+assert.strictEqual(json.imports.react, 'https://ga.jspm.io/npm:react@17.0.1/index.js');
+assert.strictEqual(json.scopes['https://ga.jspm.io/']['object-assign'], 'https://ga.jspm.io/npm:object-assign@4.1.0/index.js');

--- a/test/api/reenv.test.js
+++ b/test/api/reenv.test.js
@@ -1,24 +1,52 @@
 import { Generator } from '@jspm/generator';
 import assert from 'assert';
 
-const generator = new Generator({
-  inputMap: {
-    "imports": {
-      "react": "https://ga.jspm.io/npm:react@17.0.1/dev.index.js"
+{
+  const generator = new Generator({
+    inputMap: {
+      "imports": {
+        "react": "https://ga.jspm.io/npm:react@17.0.1/dev.index.js"
+      },
+      "scopes": {
+        "https://ga.jspm.io/": {
+          "object-assign": "https://ga.jspm.io/npm:object-assign@4.1.0/index.js"
+        }
+      }
     },
-    "scopes": {
-      "https://ga.jspm.io/": {
-        "object-assign": "https://ga.jspm.io/npm:object-assign@4.1.0/index.js"
+    mapUrl: import.meta.url,
+    defaultProvider: 'jspm',
+    env: ['production', 'browser']
+  });
+
+  await generator.reinstall();
+  const json = generator.getMap();
+
+  assert.strictEqual(json.imports.react, 'https://ga.jspm.io/npm:react@17.0.1/index.js');
+  assert.strictEqual(json.scopes['https://ga.jspm.io/']['object-assign'], 'https://ga.jspm.io/npm:object-assign@4.1.0/index.js');
+}
+
+{
+  const generator = new Generator({
+    env: ['production', 'module', 'browser'],
+    ignore: ['custom'],
+    inputMap: {
+      "imports": {
+        "custom": "/mapping.js",
+        "react": "https://ga.jspm.io/npm:react@17.0.1/dev.index.js"
+      },
+      "scopes": {
+        "https://ga.jspm.io/": {
+          "object-assign": "https://ga.jspm.io/npm:object-assign@4.1.0/index.js"
+        }
       }
     }
-  },
-  mapUrl: import.meta.url,
-  defaultProvider: 'jspm',
-  env: ['production', 'browser']
-});
+  });
 
-await generator.reinstall();
-const json = generator.getMap();
+  await generator.reinstall();
 
-assert.strictEqual(json.imports.react, 'https://ga.jspm.io/npm:react@17.0.1/index.js');
-assert.strictEqual(json.scopes['https://ga.jspm.io/']['object-assign'], 'https://ga.jspm.io/npm:object-assign@4.1.0/index.js');
+  const json = generator.getMap();
+
+  assert.strictEqual(json.imports.custom, '/mapping.js');
+  assert.strictEqual(json.imports.react, 'https://ga.jspm.io/npm:react@17.0.1/index.js');
+  assert.strictEqual(json.scopes['https://ga.jspm.io/']['object-assign'], 'https://ga.jspm.io/npm:object-assign@4.1.0/index.js');
+}

--- a/test/api/remotedep.test.js
+++ b/test/api/remotedep.test.js
@@ -11,4 +11,4 @@ await generator.install({ target: './local/pkg', subpath: './remotedep' });
 const json = generator.getMap();
 
 assert.strictEqual(json.imports['localpkg/remotedep'], './local/pkg/d.js');
-assert.strictEqual(json.scopes['./'].react, 'https://ga.jspm.io/npm:react@16.14.0/index.js');
+assert.strictEqual(json.scopes['./local/pkg/'].react, 'https://ga.jspm.io/npm:react@16.14.0/index.js');

--- a/test/api/rooturl.test.js
+++ b/test/api/rooturl.test.js
@@ -8,6 +8,7 @@ const generator = new Generator({
 });
 
 await generator.install({ target: './local/pkg', subpath: './custom' });
+
 const json = generator.getMap();
 
 assert.strictEqual(json.imports['localpkg/custom'], '/local/pkg/a.js');

--- a/test/api/traceinstall.test.js
+++ b/test/api/traceinstall.test.js
@@ -10,4 +10,4 @@ const generator = new Generator({
 await generator.traceInstall('./local/pkg/b.js');
 
 const json = generator.getMap();
-assert.strictEqual(json.scopes['./'].dep, './local/dep/main.js');
+assert.strictEqual(json.scopes['./local/pkg/'].dep, './local/dep/main.js');

--- a/test/providers/nodemodules.test.js
+++ b/test/providers/nodemodules.test.js
@@ -12,5 +12,5 @@ await generator.install('lit-html');
 const json = generator.getMap();
 
 assert.strictEqual(json.imports['lit-element'], './node_modules/lit-element/lit-element.js');
-assert.strictEqual(json.scopes['./']['lit-html/lib/shady-render.js'], './node_modules/lit-html/lib/shady-render.js');
-assert.strictEqual(json.scopes['./']['lit-html/lit-html.js'], './node_modules/lit-html/lit-html.js');
+assert.strictEqual(json.scopes['./node_modules/lit-element/']['lit-html/lib/shady-render.js'], './node_modules/lit-html/lib/shady-render.js');
+assert.strictEqual(json.scopes['./node_modules/lit-element/']['lit-html/lit-html.js'], './node_modules/lit-html/lit-html.js');

--- a/test/providers/scopeprovider.test.js
+++ b/test/providers/scopeprovider.test.js
@@ -15,5 +15,5 @@ await generator.install('lit-html');
 const json = generator.getMap();
 
 assert.strictEqual(json.imports['lit-element'], './node_modules/lit-element/lit-element.js');
-assert.ok(json.scopes['./']['lit-html/lib/shady-render.js'].startsWith('https://ga.jspm.io'));
-assert.ok(json.scopes['./']['lit-html/lit-html.js'].startsWith('https://ga.jspm.io'));
+assert.ok(json.scopes['./node_modules/lit-element/']['lit-html/lib/shady-render.js'].startsWith('https://ga.jspm.io'));
+assert.ok(json.scopes['./node_modules/lit-element/']['lit-html/lit-html.js'].startsWith('https://ga.jspm.io'));

--- a/test/resolve/builtin-shim.test.js
+++ b/test/resolve/builtin-shim.test.js
@@ -3,7 +3,6 @@ import assert from 'assert';
 
 if (typeof document === 'undefined') {
   const generator = new Generator({
-    stdlib: new URL('../../jspm-core/', import.meta.url),
     mapUrl: import.meta.url,
     defaultProvider: 'nodemodules'
   });
@@ -15,7 +14,7 @@ if (typeof document === 'undefined') {
 
   assert.deepStrictEqual(json, {
     scopes: {
-      './': {
+      './cjspkg/': {
         'process/': './cjspkg/node_modules/process/index.js',
       }
     }

--- a/test/resolve/chalk.test.js
+++ b/test/resolve/chalk.test.js
@@ -12,5 +12,5 @@ if (typeof document === 'undefined') {
   const json = generator.getMap();
 
   assert.equal(Object.keys(json.imports).length, 1);
-  assert.equal(Object.keys(json.scopes).length, 3);
+  assert.equal(Object.keys(json.scopes['../../node_modules/']).length, 4);
 }

--- a/test/resolve/nodemodules.test.js
+++ b/test/resolve/nodemodules.test.js
@@ -12,5 +12,5 @@ await generator.install('lit-html');
 const json = generator.getMap();
 
 assert.strictEqual(json.imports['lit-element'], './node_modules/lit-element/lit-element.js');
-assert.strictEqual(json.scopes['./']['lit-html/lib/shady-render.js'], './node_modules/lit-html/lib/shady-render.js');
-assert.strictEqual(json.scopes['./']['lit-html/lit-html.js'], './node_modules/lit-html/lit-html.js');
+assert.strictEqual(json.scopes['./node_modules/lit-element/']['lit-html/lib/shady-render.js'], './node_modules/lit-html/lib/shady-render.js');
+assert.strictEqual(json.scopes['./node_modules/lit-element/']['lit-html/lit-html.js'], './node_modules/lit-html/lit-html.js');


### PR DESCRIPTION
This adds a new `generator.reinstall` method which can be used to reinstall all the `"imports"` of the import map.

In the test case, we have an import map created to the development export of React. We create a generator instance to the production condition with this inputMap, then use `generator.reinstall` to get the same versions of React and its dependencies, but with the exports conditions switched into production mode.

This also updates to v1 of the @jspm/import-map project and fixes a number of input map decomposition bugs.

Works very naturally based on the new architecture, thanks @JayaKrishnaNamburu for mentioning this missing function!