### PR TITLE
feat: first-class Deno installs

### DIFF
--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -115,7 +115,7 @@ export class Installer {
         provider: opts.defaultProvider.split('.')[0],
         layer: opts.defaultProvider.split('.')[1] || 'default'
       };
-    this.providers = registryProviders;
+    this.providers = Object.assign({}, registryProviders);
     if (opts.providers)
       Object.assign(this.providers, opts.providers);
 

--- a/src/install/package.ts
+++ b/src/install/package.ts
@@ -71,7 +71,7 @@ export async function parseUrlTarget (resolver: Resolver, targetStr: string, par
 }
 
 // ad-hoc determination of local path v remote package for eg "jspm deno react" v "jspm deno react@2" v "jspm deno ./react.ts" v "jspm deno react.ts"
-const supportedRegistries = ['npm', 'github', 'deno', 'nest'];
+const supportedRegistries = ['npm', 'github', 'deno', 'nest', 'denoland'];
 export function isPackageTarget (targetStr: string): boolean {
   if (isRelative(targetStr))
     return false;
@@ -100,7 +100,7 @@ export function pkgUrlToNiceString (resolver: Resolver, pkgUrl: string) {
   return pkgUrl;
 }
 
-export async function toPackageTarget (resolver: Resolver, targetStr: string, parentPkgUrl: string): Promise<{ alias: string, target: InstallTarget, subpath: '.' | `./${string}` }> {
+export async function toPackageTarget (resolver: Resolver, targetStr: string, parentPkgUrl: string, defaultRegistry: string): Promise<{ alias: string, target: InstallTarget, subpath: '.' | `./${string}` }> {
   const urlTarget = await parseUrlTarget(resolver, targetStr, parentPkgUrl);
   if (urlTarget)
     return urlTarget;
@@ -125,12 +125,12 @@ export async function toPackageTarget (resolver: Resolver, targetStr: string, pa
 
   return {
     alias,
-    target: newPackageTarget(pkg.pkgName, parentPkgUrl),
+    target: newPackageTarget(pkg.pkgName, parentPkgUrl, defaultRegistry),
     subpath: pkg.subpath as '.' | `./{string}`
   };
 }
 
-export function newPackageTarget (target: string, parentPkgUrl: string, depName?: string): InstallTarget {
+export function newPackageTarget (target: string, parentPkgUrl: string, defaultRegistry: string, depName?: string): InstallTarget {
   let registry: string, name: string, ranges: any[];
 
   const registryIndex = target.indexOf(':');
@@ -138,7 +138,7 @@ export function newPackageTarget (target: string, parentPkgUrl: string, depName?
   if (target.startsWith('./') || target.startsWith('../') || target.startsWith('/') || registryIndex === 1)
     return new URL(target, parentPkgUrl);
 
-  registry = registryIndex < 1 ? 'npm' : target.substr(0, registryIndex);
+  registry = registryIndex < 1 ? defaultRegistry : target.slice(0, registryIndex);
 
   if (registry === 'file')
     return new URL(target.slice(registry.length + 1), parentPkgUrl);

--- a/src/providers/denoland.ts
+++ b/src/providers/denoland.ts
@@ -4,20 +4,34 @@ import { Resolver } from "../trace/resolver.js";
 import { fetch } from '#fetch';
 
 const cdnUrl = 'https://deno.land/x/';
+const stdlibUrl = 'https://deno.land/std';
 
 export function pkgToUrl (pkg: ExactPackage) {
-  return cdnUrl + pkg.name + '@v' + pkg.version + '/';
+  if (pkg.registry === 'deno')
+    return stdlibUrl + '@' + pkg.version + '/' + pkg.name + '/';
+  if (pkg.registry === 'denoland')
+    return cdnUrl + pkg.name + '@v' + pkg.version + '/';
+  throw new Error(`Deno provider does not support the ${pkg.registry} registry`);
 }
 
 export function parseUrlPkg (url: string): ExactPackage | undefined {
-  if (!url.startsWith(cdnUrl))
-    return;
-  const path = url.slice(cdnUrl.length);
-  const versionIndex = path.indexOf('@v');
-  if (versionIndex === -1)
-    return;
-  const sepIndex = path.indexOf('/', versionIndex);
-  return { registry: 'deno', name: path.slice(0, versionIndex), version: path.slice(versionIndex + 2, sepIndex === -1 ? path.length : sepIndex) };
+  if (url.startsWith(stdlibUrl) && url[stdlibUrl.length] === '@') {
+    const version = url.slice(stdlibUrl.length + 1, url.indexOf('/', stdlibUrl.length + 1));
+    let name = url.slice(stdlibUrl.length + version.length + 2);
+    if (name.endsWith('/mod.ts'))
+      name = name.slice(0, -7);
+    else if (name.endsWith('.ts'))
+      name = name.slice(0, -3);
+    return { registry: 'deno', name, version };
+  }
+  else if (url.startsWith(cdnUrl)) {
+    const path = url.slice(cdnUrl.length);
+    const versionIndex = path.indexOf('@v');
+    if (versionIndex === -1)
+      return;
+    const sepIndex = path.indexOf('/', versionIndex);
+    return { registry: 'denoland', name: path.slice(0, versionIndex), version: path.slice(versionIndex + 2, sepIndex === -1 ? path.length : sepIndex) };
+  }
 }
 
 export async function resolveLatestTarget (this: Resolver, target: LatestPackageTarget, unstable: boolean, _layer: string, parentUrl: string): Promise<ExactPackage | null> {
@@ -30,8 +44,8 @@ export async function resolveLatestTarget (this: Resolver, target: LatestPackage
     throw new Error(`Version ranges are not supported looking up in the Deno registry currently, until an API is available.`);
 
   const fetchOpts = { ...this.fetchOpts, headers: Object.assign({}, this.fetchOpts.headers || {}, { 'accept': 'text/html' }) };
-  const res = await fetch(cdnUrl + name, fetchOpts);
+  const res = await fetch((registry === 'denoland' ? cdnUrl : stdlibUrl + '/') + name, fetchOpts);
   if (!res.ok)
-    throw new Error(`Deno: Unable to lookup ${cdnUrl + name}`);
+    throw new Error(`Deno: Unable to lookup ${(registry === 'denoland' ? cdnUrl : stdlibUrl + '/') + name}`);
   return parseUrlPkg(res.url);
 }

--- a/src/providers/denoland.ts
+++ b/src/providers/denoland.ts
@@ -43,8 +43,16 @@ export async function resolveLatestTarget (this: Resolver, target: LatestPackage
   if (!range.isWildcard)
     throw new Error(`Version ranges are not supported looking up in the Deno registry currently, until an API is available.`);
 
-  const fetchOpts = { ...this.fetchOpts, headers: Object.assign({}, this.fetchOpts.headers || {}, { 'accept': 'text/html' }) };
-  const res = await fetch((registry === 'denoland' ? cdnUrl : stdlibUrl + '/') + name, fetchOpts);
+  const fetchOpts = {
+    ...this.fetchOpts,
+    headers: Object.assign({}, this.fetchOpts.headers || {}, {
+      // For some reason, Deno provides different redirect behaviour for the server
+      // Which requires us to use the text/html accept
+      'accept': typeof document === 'undefined' ? 'text/html' : 'text/javascript'
+    })
+  };
+  // "mod.ts" addition is necessary for the browser otherwise not resolving an exact module gives a CORS error
+  const res = await fetch((registry === 'denoland' ? cdnUrl : stdlibUrl + '/') + name + '/mod.ts', fetchOpts);
   if (!res.ok)
     throw new Error(`Deno: Unable to lookup ${(registry === 'denoland' ? cdnUrl : stdlibUrl + '/') + name}`);
   return parseUrlPkg(res.url);

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -1,4 +1,4 @@
-import * as deno from './denoland.js';
+import * as denoland from './denoland.js';
 import * as jspm from './jspm.js';
 import * as skypack from './skypack.js';
 import * as jsdelivr from './jsdelivr.js';
@@ -18,7 +18,7 @@ export interface Provider {
 }
 
 export const defaultProviders: Record<string, Provider> = {
-  deno,
+  denoland,
   jsdelivr,
   jspm,
   node,
@@ -33,3 +33,8 @@ export function getProvider (name: string, providers: Record<string, Provider> =
     return provider;
   throw new Error('No ' + name + ' provider is defined.');
 }
+
+export const registryProviders: Record<string, string> = {
+  'denoland:': 'denoland',
+  'deno:': 'denoland'
+};

--- a/test/providers/deno.test.js
+++ b/test/providers/deno.test.js
@@ -1,13 +1,35 @@
 import { Generator } from '@jspm/generator';
 import assert from 'assert';
 
-const generator = new Generator({
-  mapUrl: new URL('../../', import.meta.url),
-  defaultProvider: 'deno'
-});
+{
+  const generator = new Generator({
+    mapUrl: new URL('../../', import.meta.url),
+    defaultRegistry: 'denoland'
+  });
 
-await generator.install('oak@10.6.0');
+  await generator.install('oak@10.6.0');
 
-const json = generator.getMap();
+  const json = generator.getMap();
 
-assert.strictEqual(json.imports['oak'], 'https://deno.land/x/oak@v10.6.0/mod.ts');
+  assert.strictEqual(json.imports['oak'], 'https://deno.land/x/oak@v10.6.0/mod.ts');
+}
+
+{
+  const generator = new Generator();
+
+  await generator.install('denoland:oak');
+
+  const json = generator.getMap();
+
+  assert.strictEqual(json.imports['oak'], 'https://deno.land/x/oak@v10.6.0/mod.ts');
+}
+
+{
+  const generator = new Generator();
+
+  await generator.install('deno:path');
+
+  const json = generator.getMap();
+
+  assert.strictEqual(json.imports['path'], 'https://deno.land/std@0.148.0/path/mod.ts');
+}


### PR DESCRIPTION
This adds support for first-class Deno installs via the recently-added Deno provider.

Specifically:

* `generator.install('deno:path')` corresponds to a stdlib install and will populate a versioned stdlib mapping for `path` to the Deno standard librariy.
* `generator.install('denoland:oak')` corresponds to a third-party Deno.land install and will populate the mapping similarly.

In addition a new `defaultRegistry` option is added as well as the ability for the `providers` object to provide registry mappings.

`defaultRegistry` applies the default registry for `generator.install('x')` to default to `generator.install('registry:x')` with the default obviously being `npm:`.

`providers` having custom `registry:` entries allows custom registry provider mappings via `new Generator({ providers: { 'npm:': 'unpkg', 'denoland:': 'custom' } })` sort of thing ensuring this all is consistent with the provider and registry separation model.