### PR TITLE
feat: generator update API

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "@babel/preset-typescript": "^7.17.2",
     "@jspm/core": "^2.0.0-beta.8",
     "@jspm/import-map": "^1.0.4",
-    "es-module-lexer": "^1.0.2",
+    "es-module-lexer": "^1.0.3",
     "ipfs-client": "^0.7.1",
     "make-fetch-happen": "^8.0.3",
     "sver": "^1.8.3"

--- a/src/providers/jspm.ts
+++ b/src/providers/jspm.ts
@@ -157,6 +157,8 @@ export async function resolveLatestTarget (this: Resolver, target: LatestPackage
   if (stableFallback || range.isStable) {
     const minor = `${range.version.major}.${range.version.minor}`;
     let lookup = await (cache.minors[minor] || (cache.minors[minor] = lookupRange.call(this, registry, name, minor, unstable, parentUrl)));
+    // in theory a similar downgrade to the above can happen for stable prerelease ranges ~1.2.3-pre being downgraded to 1.2.2
+    // this will be solved by the pkg@X.Y@ unstable minor lookup
     // Deno wat?
     if (lookup instanceof Promise)
       lookup = await lookup;

--- a/test/api/update.test.js
+++ b/test/api/update.test.js
@@ -5,14 +5,11 @@ import assert from 'assert';
   const generator = new Generator({
     inputMap: {
       "imports": {
-        "react": "https://ga.jspm.io/npm:react@17.0.1/dev.index.js",
-        "react-dom": "https://ga.jspm.io/npm:react-dom@17.0.1/dev.index.js"
+        "react": "https://ga.jspm.io/npm:react@17.0.1/dev.index.js"
       },
       "scopes": {
         "https://ga.jspm.io/": {
-          "object-assign": "https://ga.jspm.io/npm:object-assign@4.1.0/index.js",
-          "scheduler": "https://ga.jspm.io/npm:scheduler@0.20.1/dev.index.js",
-          "scheduler/tracing": "https://ga.jspm.io/npm:scheduler@0.20.1/dev.tracing.js"
+          "object-assign": "https://ga.jspm.io/npm:object-assign@4.1.0/index.js"
         }
       }
     },
@@ -21,11 +18,11 @@ import assert from 'assert';
     env: ['production', 'browser']
   });
 
-  await generator.uninstall('react-dom');
+  await generator.update('react');
   const json = generator.getMap();
 
-  assert.strictEqual(json.imports.react, 'https://ga.jspm.io/npm:react@17.0.1/index.js');
-  assert.strictEqual(json.scopes['https://ga.jspm.io/']['object-assign'], 'https://ga.jspm.io/npm:object-assign@4.1.0/index.js');
+  assert.strictEqual(json.imports.react, 'https://ga.jspm.io/npm:react@17.0.2/index.js');
+  assert.strictEqual(json.scopes['https://ga.jspm.io/']['object-assign'], 'https://ga.jspm.io/npm:object-assign@4.1.1/index.js');
   assert.strictEqual(Object.keys(json.imports).length, 1);
   assert.strictEqual(Object.keys(json.scopes['https://ga.jspm.io/']).length, 1);
 }
@@ -51,7 +48,9 @@ import assert from 'assert';
     env: ['production', 'browser']
   });
 
-  await generator.uninstall(['lit', 'lit/']);
+  await generator.update('lit');
   const json = generator.getMap();
-  assert.strictEqual(Object.keys(json).length, 0);
+
+  assert.strictEqual(json.imports.lit, 'https://ga.jspm.io/npm:lit@2.2.8/index.js');
+  assert.strictEqual(json.imports['lit/directive.js'], 'https://ga.jspm.io/npm:lit@2.2.8/directive.js');
 }


### PR DESCRIPTION
This adds a new `generator.update('pkg')` API, taking package names (not specifiers like all other forms) to update. Resolves https://github.com/jspm/generator/issues/148.

The uninstall API has also been updated to support `pkg/` style shorthands to remove all subpaths of a package in one operation instead of needing to be explicitly enumerated.