### PR TITLE
feat: unstable installs via install(pkg@)

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -625,7 +625,7 @@ export class Generator {
 
     let esms = '';
     if (esModuleShims) {
-      const { pkg: esmsPkg } = await this.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, this.traceMap.installer.defaultProvider);
+      const { pkg: esmsPkg } = await this.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')], unstable: false }, this.traceMap.installer.defaultProvider);
       const esmsUrl = this.traceMap.resolver.pkgToUrl(esmsPkg, this.traceMap.installer.defaultProvider) + 'dist/es-module-shims.js';
       esms = `<script async src="${esmsUrl}" crossorigin="anonymous"${integrity ? ` integrity="${await getIntegrity(esmsUrl, this.traceMap.resolver.fetchOpts)}"` : ''}></script>${newlineTab}`;
       
@@ -798,7 +798,7 @@ export class Generator {
         const pkg = this.traceMap.resolver.parseUrlPkg(resolution.installUrl);
         if (!pkg)
           throw new Error(`Unable to determine a package version lookup for ${name}. Make sure it is supported as a provider package.`);
-        const target = { registry: pkg.pkg.registry, name: pkg.pkg.name, ranges: [new SemverRange('^' + pkg.pkg.version)] };
+        const target = { registry: pkg.pkg.registry, name: pkg.pkg.name, ranges: [new SemverRange('^' + pkg.pkg.version)], unstable: false };
         installs.push({ alias: name, subpaths, target });
       }
     }
@@ -945,7 +945,7 @@ export async function lookup (install: string | Install, { provider, cache }: Lo
   const { target, subpath, alias } = await installToTarget.call(generator, install, generator.traceMap.installer.defaultRegistry);
   if (target instanceof URL)
     throw new Error('URL lookups not supported');
-  const resolved = await generator.traceMap.resolver.resolveLatestTarget(target, true, generator.traceMap.installer.getProvider(target));
+  const resolved = await generator.traceMap.resolver.resolveLatestTarget(target, generator.traceMap.installer.getProvider(target));
   return {
     install: {
       target: {

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -232,7 +232,7 @@ export class Installer {
         return this.installTarget(pkgName, resolutionTarget, mode, pkgScope, parentUrl);
     }
 
-    const latest = await this.resolver.resolveLatestTarget(target, false, provider, parentUrl);
+    const latest = await this.resolver.resolveLatestTarget(target, provider, parentUrl);
     const latestUrl = this.resolver.pkgToUrl(latest.pkg, provider);
     const installed = getInstallsFor(this.constraints, latest.pkg.registry, latest.pkg.name);
     if (!this.opts.freeze && !this.tryUpgradeAllTo(latest.pkg, latestUrl, installed)) {
@@ -294,7 +294,7 @@ export class Installer {
 
     // node.js core
     if (nodeBuiltins && nodeBuiltinSet.has(pkgName)) {
-      return this.installTarget(pkgName, { registry: 'node', name: pkgName, ranges: [new SemverRange('*')] }, mode, pkgScope, parentUrl);
+      return this.installTarget(pkgName, { registry: 'node', name: pkgName, ranges: [new SemverRange('*')], unstable: true }, mode, pkgScope, parentUrl);
     }
 
     // package dependencies

--- a/src/install/lock.ts
+++ b/src/install/lock.ts
@@ -174,16 +174,16 @@ function packageTargetFromExact (pkg: ExactPackage, permitDowngrades = false): P
   const { registry, name, version } = pkg;
   const v = new Semver(version);
   if (v.tag)
-    return { registry, name, ranges: [new SemverRange(version)] };;
+    return { registry, name, ranges: [new SemverRange(version)], unstable: false };;
   if (permitDowngrades) {
     if (v.major !== 0)
-      return { registry, name, ranges: [new SemverRange(v.major) ]};
+      return { registry, name, ranges: [new SemverRange(v.major) ], unstable: false};
     if (v.minor !== 0)
-      return { registry, name, ranges: [new SemverRange(v.major + '.' + v.minor) ]};
-    return { registry, name, ranges: [new SemverRange(version) ]};
+      return { registry, name, ranges: [new SemverRange(v.major + '.' + v.minor) ], unstable: false };
+    return { registry, name, ranges: [new SemverRange(version) ], unstable: false };
   }
   else {
-    return { registry, name, ranges: [new SemverRange('^' + version)] };
+    return { registry, name, ranges: [new SemverRange('^' + version)], unstable: false };
   }
 }
 

--- a/src/install/package.ts
+++ b/src/install/package.ts
@@ -38,12 +38,14 @@ export interface PackageTarget {
   registry: string;
   name: string;
   ranges: any[];
+  unstable: boolean;
 }
 
 export interface LatestPackageTarget {
   registry: string;
   name: string;
   range: any;
+  unstable: boolean;
 }
 
 const supportedProtocols = ['https', 'http', 'data', 'file', 'ipfs'];
@@ -146,10 +148,13 @@ export function newPackageTarget (target: string, parentPkgUrl: URL, defaultRegi
     return new URL(target);
 
   const versionIndex = target.lastIndexOf('@');
+  let unstable = false;
   if (versionIndex > registryIndex + 1) {
     name = target.slice(registryIndex + 1, versionIndex);
     const version = target.slice(versionIndex + 1);
     ranges = (depName || SemverRange.isValid(version)) ? [new SemverRange(version)] : version.split('||').map(v => convertRange(v));
+    if (version === '')
+      unstable = true;
   }
   else if (registryIndex === -1 && depName) {
     name = depName;
@@ -167,7 +172,7 @@ export function newPackageTarget (target: string, parentPkgUrl: URL, defaultRegi
   if (targetNameLen > 2 || targetNameLen === 1 && name[0] === '@')
     throw new JspmError(`Invalid package target ${target}`);
 
-  return { registry, name, ranges };
+  return { registry, name, ranges, unstable };
 }
 
 export function pkgToStr (pkg: ExactPackage) {

--- a/src/providers/denoland.ts
+++ b/src/providers/denoland.ts
@@ -35,7 +35,7 @@ export function parseUrlPkg (url: string): { pkg: ExactPackage, subpath: `./${st
   }
 }
 
-export async function resolveLatestTarget (this: Resolver, target: LatestPackageTarget, unstable: boolean, _layer: string, parentUrl: string): Promise<{ pkg: ExactPackage, subpath: `./${string}` | null } | null> {
+export async function resolveLatestTarget (this: Resolver, target: LatestPackageTarget, _layer: string, parentUrl: string): Promise<{ pkg: ExactPackage, subpath: `./${string}` | null } | null> {
   const { registry, name, range } = target;
 
   if (range.isExact)

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -11,7 +11,7 @@ import { Resolver } from '../trace/resolver.js';
 export interface Provider {
   parseUrlPkg (this: Resolver, url: string): ExactPackage | { pkg: ExactPackage, subpath: `./${string}` | null, layer: string } | undefined;
   pkgToUrl (this: Resolver, pkg: ExactPackage, layer: string): string;
-  resolveLatestTarget (this: Resolver, target: LatestPackageTarget, unstable: boolean, layer: string, parentUrl: string): Promise<ExactPackage | { pkg: ExactPackage, subpath: `./${string}` } | null>;
+  resolveLatestTarget (this: Resolver, target: LatestPackageTarget, layer: string, parentUrl: string): Promise<ExactPackage | { pkg: ExactPackage, subpath: `./${string}` } | null>;
 
   getPackageConfig? (this: Resolver, pkgUrl: string): Promise<PackageConfig | null | undefined>;
   // getFileList? (this: Resolver, pkgUrl: string): Promise<string[]>;

--- a/src/providers/jspm.ts
+++ b/src/providers/jspm.ts
@@ -94,8 +94,8 @@ async function ensureBuild (pkg: ExactPackage, fetchOpts: any) {
   }
 }
 
-export async function resolveLatestTarget (this: Resolver, target: LatestPackageTarget, unstable: boolean, _layer: string, parentUrl: string): Promise<ExactPackage | { pkg: ExactPackage, subpath: `./${string}` | null } | null> {
-  const { registry, name, range } = target;
+export async function resolveLatestTarget (this: Resolver, target: LatestPackageTarget, _layer: string, parentUrl: string): Promise<ExactPackage | { pkg: ExactPackage, subpath: `./${string}` | null } | null> {
+  const { registry, name, range, unstable } = target;
 
   // exact version optimization
   if (range.isExact && !range.version.tag) {

--- a/src/providers/node.ts
+++ b/src/providers/node.ts
@@ -44,8 +44,8 @@ export async function getPackageConfig () {
   return null;
 }
 
-export async function resolveLatestTarget (this: Resolver, target: LatestPackageTarget, unstable: boolean, _layer: string, parentUrl: string): Promise<{ pkg: ExactPackage, subpath: `./${string}` } | null> {
-  let resolved = (await jspmResolveLatestTarget.call(this, { registry: 'npm', name: '@jspm/core', range: new SemverRange('*') }, unstable, _layer, parentUrl)) as ExactPackage | { pkg: ExactPackage, subpath: `./${string}` | null } | null;
+export async function resolveLatestTarget (this: Resolver, target: LatestPackageTarget, _layer: string, parentUrl: string): Promise<{ pkg: ExactPackage, subpath: `./${string}` } | null> {
+  let resolved = (await jspmResolveLatestTarget.call(this, { registry: 'npm', name: '@jspm/core', range: new SemverRange('*') }, _layer, parentUrl)) as ExactPackage | { pkg: ExactPackage, subpath: `./${string}` | null } | null;
   if (!resolved)
     return null;
   const pkg = 'pkg' in resolved ? resolved.pkg : resolved;

--- a/src/providers/nodemodules.ts
+++ b/src/providers/nodemodules.ts
@@ -33,10 +33,10 @@ async function dirExists (url: URL, parentUrl?: string) {
   }
 }
 
-export async function resolveLatestTarget (this: Resolver, target: LatestPackageTarget, _unstable: boolean, _layer: string, parentUrl: string): Promise<ExactPackage | null> {
+export async function resolveLatestTarget (this: Resolver, target: LatestPackageTarget, _layer: string, parentUrl: string): Promise<ExactPackage | null> {
   let curUrl = new URL(`node_modules/${target.name}`, parentUrl);
   const rootUrl = new URL(`/node_modules/${target.name}`, parentUrl).href;
-  while (!(await dirExists.call(this, curUrl))) {
+  while (!(await dirExists.call(this, curUrl))) {b
     if (curUrl.href === rootUrl)
       return null;
     curUrl = new URL(`../../${target.name.indexOf('/') === -1 ? '' : '../'}node_modules/${target.name}`, curUrl);

--- a/src/providers/nodemodules.ts
+++ b/src/providers/nodemodules.ts
@@ -36,7 +36,7 @@ async function dirExists (url: URL, parentUrl?: string) {
 export async function resolveLatestTarget (this: Resolver, target: LatestPackageTarget, _layer: string, parentUrl: string): Promise<ExactPackage | null> {
   let curUrl = new URL(`node_modules/${target.name}`, parentUrl);
   const rootUrl = new URL(`/node_modules/${target.name}`, parentUrl).href;
-  while (!(await dirExists.call(this, curUrl))) {b
+  while (!(await dirExists.call(this, curUrl))) {
     if (curUrl.href === rootUrl)
       return null;
     curUrl = new URL(`../../${target.name.indexOf('/') === -1 ? '' : '../'}node_modules/${target.name}`, curUrl);

--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -166,7 +166,7 @@ export class Resolver {
     }
   }
 
-  async resolveLatestTarget (target: PackageTarget, unstable: boolean, { provider, layer }: PackageProvider, parentUrl?: string): Promise<{ pkg: ExactPackage, subpath: `./${string}` | null }> {
+  async resolveLatestTarget (target: PackageTarget, { provider, layer }: PackageProvider, parentUrl?: string): Promise<{ pkg: ExactPackage, subpath: `./${string}` | null }> {
     // find the range to resolve latest
     let range: any;
     for (const possibleRange of target.ranges.sort(target.ranges[0].constructor.compare)) {
@@ -178,9 +178,9 @@ export class Resolver {
       }
     }
 
-    const latestTarget = { registry: target.registry, name: target.name, range };
+    const latestTarget = { registry: target.registry, name: target.name, range, unstable: target.unstable };
 
-    const pkg = await getProvider(provider, this.providers).resolveLatestTarget.call(this, latestTarget, unstable, layer, parentUrl) as ExactPackage | { pkg: ExactPackage, subpath: `./${string}` | null } | null;
+    const pkg = await getProvider(provider, this.providers).resolveLatestTarget.call(this, latestTarget, layer, parentUrl) as ExactPackage | { pkg: ExactPackage, subpath: `./${string}` | null } | null;
     if (pkg) {
       if ('pkg' in pkg)
         return pkg;

--- a/test/api/install-dedupe.test.js
+++ b/test/api/install-dedupe.test.js
@@ -24,4 +24,4 @@ const generator = new Generator({
 await generator.install('lit@2.3/html.js');
 const json = generator.getMap();
 
-assert.strictEqual(json.imports.lit, 'https://ga.jspm.io/npm:lit@2.3.0-next.1/index.js');
+assert.strictEqual(json.imports.lit, 'https://ga.jspm.io/npm:lit@2.3.0/index.js');

--- a/test/api/update.test.js
+++ b/test/api/update.test.js
@@ -51,6 +51,6 @@ import assert from 'assert';
   await generator.update('lit');
   const json = generator.getMap();
 
-  assert.strictEqual(json.imports.lit, 'https://ga.jspm.io/npm:lit@2.2.8/index.js');
-  assert.strictEqual(json.imports['lit/directive.js'], 'https://ga.jspm.io/npm:lit@2.2.8/directive.js');
+  assert.strictEqual(json.imports.lit, 'https://ga.jspm.io/npm:lit@2.3.0/index.js');
+  assert.strictEqual(json.imports['lit/directive.js'], 'https://ga.jspm.io/npm:lit@2.3.0/directive.js');
 }

--- a/test/html/breaks.test.js
+++ b/test/html/breaks.test.js
@@ -10,7 +10,7 @@ const generator = new Generator({
   }
 });
 
-const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);
+const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, generator.traceMap.installer.defaultProvider);
 const esmsUrl = generator.traceMap.resolver.pkgToUrl(esmsPkg, generator.traceMap.installer.defaultProvider) + 'dist/es-module-shims.js';
 
 assert.strictEqual(await generator.htmlGenerate(`<!DOCTYPE html>

--- a/test/html/emptymap.test.js
+++ b/test/html/emptymap.test.js
@@ -7,7 +7,7 @@ const generator = new Generator({
   env: ['production', 'browser']
 });
 
-const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);
+const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, generator.traceMap.installer.defaultProvider);
 const esmsUrl = generator.traceMap.resolver.pkgToUrl(esmsPkg, generator.traceMap.installer.defaultProvider) + 'dist/es-module-shims.js';
 
 assert.strictEqual(await generator.htmlGenerate(`<!DOCTYPE html>

--- a/test/html/indent.test.js
+++ b/test/html/indent.test.js
@@ -10,7 +10,7 @@ const generator = new Generator({
   }
 });
 
-const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);
+const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, generator.traceMap.installer.defaultProvider);
 const esmsUrl = generator.traceMap.resolver.pkgToUrl(esmsPkg, generator.traceMap.installer.defaultProvider) + 'dist/es-module-shims.js';
 
 assert.strictEqual(await generator.htmlGenerate(`

--- a/test/html/inject.test.js
+++ b/test/html/inject.test.js
@@ -7,7 +7,7 @@ const generator = new Generator({
   env: ['production', 'browser']
 });
 
-const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);
+const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, generator.traceMap.installer.defaultProvider);
 const esmsUrl = generator.traceMap.resolver.pkgToUrl(esmsPkg, generator.traceMap.installer.defaultProvider) + 'dist/es-module-shims.js';
 
 assert.strictEqual(await generator.htmlGenerate(`

--- a/test/html/injectionpoint.test.js
+++ b/test/html/injectionpoint.test.js
@@ -10,7 +10,7 @@ const generator = new Generator({
   }
 });
 
-const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);
+const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, generator.traceMap.installer.defaultProvider);
 const esmsUrl = generator.traceMap.resolver.pkgToUrl(esmsPkg, generator.traceMap.installer.defaultProvider) + 'dist/es-module-shims.js';
 
 assert.strictEqual(await generator.htmlGenerate(`<!DOCTYPE html>

--- a/test/html/inline.test.js
+++ b/test/html/inline.test.js
@@ -10,7 +10,7 @@ const generator = new Generator({
   }
 });
 
-const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);
+const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, generator.traceMap.installer.defaultProvider);
 const esmsUrl = generator.traceMap.resolver.pkgToUrl(esmsPkg, generator.traceMap.installer.defaultProvider) + 'dist/es-module-shims.js';
 
 assert.strictEqual(await generator.htmlGenerate(`

--- a/test/html/lit.test.js
+++ b/test/html/lit.test.js
@@ -13,7 +13,7 @@ const generator = new Generator({
   }
 });
 
-const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);
+const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, generator.traceMap.installer.defaultProvider);
 const esmsUrl = generator.traceMap.resolver.pkgToUrl(esmsPkg, generator.traceMap.installer.defaultProvider) + 'dist/es-module-shims.js';
 
 assert.strictEqual(await generator.htmlGenerate(`

--- a/test/html/maps.test.js
+++ b/test/html/maps.test.js
@@ -10,7 +10,7 @@ const generator = new Generator({
   }
 });
 
-const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);
+const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, generator.traceMap.installer.defaultProvider);
 const esmsUrl = generator.traceMap.resolver.pkgToUrl(esmsPkg, generator.traceMap.installer.defaultProvider) + 'dist/es-module-shims.js';
 
 assert.strictEqual(await generator.htmlGenerate(`

--- a/test/html/multi.test.js
+++ b/test/html/multi.test.js
@@ -42,7 +42,7 @@ const generator = new Generator({
   env: ['production', 'browser']
 });
 
-const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);
+const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, generator.traceMap.installer.defaultProvider);
 const esmsUrl = generator.traceMap.resolver.pkgToUrl(esmsPkg, generator.traceMap.installer.defaultProvider) + 'dist/es-module-shims.js';
 
 await generator.pin('lit/html.js');

--- a/test/html/preload.test.js
+++ b/test/html/preload.test.js
@@ -8,7 +8,7 @@ const generator = new Generator({
   env: ['production', 'browser']
 });
 
-const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);
+const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, generator.traceMap.installer.defaultProvider);
 const esmsUrl = generator.traceMap.resolver.pkgToUrl(esmsPkg, generator.traceMap.installer.defaultProvider) + 'dist/es-module-shims.js';
 const esmsIntegrity = await getIntegrity(esmsUrl, {});
 

--- a/test/html/ws.test.js
+++ b/test/html/ws.test.js
@@ -10,7 +10,7 @@ let generator = new Generator({
   }
 });
 
-const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, false, generator.traceMap.installer.defaultProvider);
+const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, generator.traceMap.installer.defaultProvider);
 const esmsUrl = generator.traceMap.resolver.pkgToUrl(esmsPkg, generator.traceMap.installer.defaultProvider) + 'dist/es-module-shims.js';
 
 assert.strictEqual(await generator.htmlGenerate(`

--- a/test/providers/custom.test.js
+++ b/test/providers/custom.test.js
@@ -17,7 +17,7 @@ const generator = new Generator({
           return { registry: 'npm', name, version };
         }
       },
-      resolveLatestTarget ({ registry, name, range }, unstable, layer, parentUrl) {
+      resolveLatestTarget ({ registry, name, range, unstable }, layer, parentUrl) {
         return { registry, name, version: '3.6.0' };
       }
     }


### PR DESCRIPTION
This explicitly adds support for `generator.install('pkg@/subpath')` for installing the latest edge version of a dependency.

Resolves https://github.com/jspm/generator/issues/166.