### PR TITLE
fix: strip baseuri hash and querystring

### DIFF
--- a/src/common/url.ts
+++ b/src/common/url.ts
@@ -23,6 +23,7 @@ else if (typeof document as any !== 'undefined') {
 if (!baseUrl && typeof location !== 'undefined') {
   baseUrl = new URL(location.href);
 }
+baseUrl.search = baseUrl.hash = undefined;;
 
 export function resolveUrl (url: string, mapUrl: URL, rootUrl: URL | null): string {
   if (url.startsWith('/'))


### PR DESCRIPTION
Resolves https://github.com/jspm/generator/issues/168, ensuring that the baseURI hash and querystring are removed.