### PR TITLE
feat: reinstate trace install

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,7 +192,7 @@ The second HTML Generation options include:
 
 * `htmlUrl`: The URL of the HTML file for relative path handling in the map
 * `rootUrl`: The root URL of the HTML file for root-relative path handling in the map
-* `trace`: Whether to trace the HTML imports before injection (via `generator.pin`)
+* `trace`: Whether to trace the HTML imports before injection (via `generator.traceInstall`)
 * `pins`: List of top-level pinned `"imports"` to inject, or `true` to inject all (the default if not tracing).
 * `comment`: Defaults to `Built with @jspm/generator` comment, set to false or an empty string to remove.
 * `preload`: Boolean, injects `<link rel="modulepreload">` preload tags. By default only injects static dependencies. Set to `'all'` to inject dyamic import preloads as well (this is the default when applying `integrity`).
@@ -242,8 +242,7 @@ To execute the application, the import map needs to be included in the HTML dire
 </script>
 ```
 
-With the import map embedded in the page, all `import` statements will have access to the defined mappings
-allowing direct `import 'lit/html.js'` style JS code in the browser.
+With the import map embedded in the page, all `import` statements will have access to the defined mappings allowing direct `import 'lit/html.js'` style JS code in the browser.
 
 For browsers without import maps, it is recommended to use the [ES Module Shims](https://github.com/guybedford/es-module-shims) import maps polyfill.
 This is a highly optimized polyfill supporting almost native speeds, see [the performance benchmarks](https://github.com/guybedford/es-module-shims/blob/main/bench/README.md) for more information.
@@ -253,19 +252,18 @@ modules have yet executed on the page. For dynamic import map injection workflow
 for each import map and injecting it into this frame can be used to get around this constraint for
 in-page refreshing application workflows.
 
-### Traced Pins
+### Trace Install
 
 Instead of installing specific packages into the map, you can also just trace any module
 module directly and JSPM will generate the scoped mappings to support that modules execution.
 
-We do this via `generator.pin` because we want to be explicit that this graph is being included
-in the import map (unused mappings are always pruned if not pinned as "imports" or custom pins).
+We do this via `generator.traceInstall` because we want to be explicit that this graph is being included in the import map (unused mappings are always pruned if not pinned as "imports" or custom pins).
 
 generate.mjs
 ```js
 // all static and dynamic dependencies necessary to execute app will be traced and
 // put into the map as necessary
-await generator.pin('./app.js');
+await generator.traceInstall('./app.js');
 ```
 
 The benefit of tracing is that it directly implements a Node.js-compatible resolver so that if you can trace something

--- a/chompfile.toml
+++ b/chompfile.toml
@@ -97,7 +97,7 @@ run = '''
 
     const generator = new Generator({
         mapUrl: new URL('./test/test.html', import.meta.url.replace('//[', '/[')),
-        env: ['browser', 'module', 'production', 'source']
+        env: ['browser', 'module', 'production']
     });
 
     await generator.traceInstall('@jspm/generator');

--- a/chompfile.toml
+++ b/chompfile.toml
@@ -88,6 +88,7 @@ run = '''
 '''
 
 [[task]]
+env = { NODE_OPTIONS = "-C source" }
 target = 'test/test.html'
 dep = 'src/**/*.ts'
 engine = 'node'
@@ -96,15 +97,15 @@ run = '''
     import { readFile, writeFile } from 'fs/promises';
 
     const generator = new Generator({
-        mapUrl: import.meta.url,
-        env: ['browser', 'module', 'production']
+        mapUrl: new URL('./test/test.html', import.meta.url.replace('//[', '/[')),
+        env: ['browser', 'module', 'production', 'source']
     });
 
-    await generator.pin('@jspm/generator');
+    await generator.traceInstall('@jspm/generator');
     await generator.install('node:assert');
 
     const html = await generator.htmlInject(await readFile(process.env.TARGET, 'utf8'), {
-        htmlUrl: new URL(process.env.TARGET, import.meta.url)
+        htmlUrl: new URL(process.env.TARGET, import.meta.url.replace('//[', '/['))
     });
     await writeFile(process.env.TARGET, html);
 '''

--- a/chompfile.toml
+++ b/chompfile.toml
@@ -88,7 +88,6 @@ run = '''
 '''
 
 [[task]]
-env = { NODE_OPTIONS = "-C source" }
 target = 'test/test.html'
 dep = 'src/**/*.ts'
 engine = 'node'

--- a/package-lock.json
+++ b/package-lock.json
@@ -748,15 +748,6 @@
         }
       }
     },
-    "node_modules/@swc/cli/node_modules/source-map": {
-      "version": "0.7.3",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-      "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-      "dev": true,
-      "engines": {
-        "node": ">= 8"
-      }
-    },
     "node_modules/@swc/core": {
       "version": "1.2.174",
       "resolved": "https://registry.npmjs.org/@swc/core/-/core-1.2.174.tgz",
@@ -3268,6 +3259,15 @@
         "node": ">= 6"
       }
     },
+    "node_modules/source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true,
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/ssri": {
       "version": "8.0.1",
       "resolved": "https://registry.npmjs.org/ssri/-/ssri-8.0.1.tgz",
@@ -4199,14 +4199,6 @@
         "fast-glob": "^3.2.5",
         "slash": "3.0.0",
         "source-map": "^0.7.3"
-      },
-      "dependencies": {
-        "source-map": {
-          "version": "0.7.3",
-          "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.3.tgz",
-          "integrity": "sha512-CkCj6giN3S+n9qrYiBTX5gystlENnRW5jZeNLHpe6aue+SrHcG5VYwujhW9s4dY31mEGsxBDrHR6oI69fTXsaQ==",
-          "dev": true
-        }
       }
     },
     "@swc/core": {
@@ -6034,6 +6026,12 @@
         "debug": "4",
         "socks": "^2.3.3"
       }
+    },
+    "source-map": {
+      "version": "0.7.4",
+      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.7.4.tgz",
+      "integrity": "sha512-l3BikUxvPOcn5E74dZiq5BGsTb5yEwhaTSzccU6t4sDOH8NWJCstKO5QT2CvtFoK6F0saL7p9xHAqHOlCPJygA==",
+      "dev": true
     },
     "ssri": {
       "version": "8.0.1",

--- a/src/common/url.ts
+++ b/src/common/url.ts
@@ -7,6 +7,18 @@ declare global {
   var process: any;
 }
 
+export function isMappableScheme (specifier) {
+  return specifier.startsWith('node:');
+}
+
+export function isKnownProtocol (protocol) {
+  return protocol === 'file:' ||
+      protocol === 'https:' ||
+      protocol === 'http:' ||
+      protocol === 'node:' ||
+      protocol === 'data:';
+}
+
 export let baseUrl: URL;
 // @ts-ignore
 if (typeof Deno !== 'undefined') {

--- a/src/common/url.ts
+++ b/src/common/url.ts
@@ -8,7 +8,7 @@ declare global {
 }
 
 export function isMappableScheme (specifier) {
-  return specifier.startsWith('node:');
+  return specifier.startsWith('node:') || specifier.startsWith('deno:');
 }
 
 export function isKnownProtocol (protocol) {
@@ -16,7 +16,8 @@ export function isKnownProtocol (protocol) {
       protocol === 'https:' ||
       protocol === 'http:' ||
       protocol === 'node:' ||
-      protocol === 'data:';
+      protocol === 'data:' ||
+      protocol === 'deno:';
 }
 
 export let baseUrl: URL;

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -489,7 +489,7 @@ export class Generator {
       this.traceMap.startInstall();
     await this.traceMap.processInputMap;
     try {
-      await this.traceMap.visit(specifier, { mode: 'new-primary', toplevel: true }, parentUrl || this.mapUrl.href);
+      await this.traceMap.visit(specifier, { mode: 'new', toplevel: true }, parentUrl || this.mapUrl.href);
       this.traceMap.pins.push(specifier);
     }
     catch (e) {
@@ -744,7 +744,7 @@ export class Generator {
         ({ alias, target, subpath } = install);
       }
       await this.traceMap.add(alias, target);
-      await this.traceMap.visit(alias + subpath.slice(1), { mode: 'new-primary', toplevel: true }, this.mapUrl.href);
+      await this.traceMap.visit(alias + subpath.slice(1), { mode: 'new', toplevel: true }, this.mapUrl.href);
       if (!this.traceMap.pins.includes(alias + subpath.slice(1)))
         this.traceMap.pins.push(alias + subpath.slice(1));
     }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -489,9 +489,8 @@ export class Generator {
       this.traceMap.startInstall();
     await this.traceMap.processInputMap;
     try {
-      await this.traceMap.visit(specifier, { mode: 'new-primary', traceinstall: true }, parentUrl);
-      if ((isPlain(specifier) || isMappableScheme(specifier)) && !this.traceMap.pins.includes(specifier))
-        this.traceMap.pins.push(specifier);
+      await this.traceMap.visit(specifier, { mode: 'new-primary', toplevel: true }, parentUrl || this.mapUrl.href);
+      this.traceMap.pins.push(specifier);
     }
     catch (e) {
       error = true;
@@ -745,7 +744,7 @@ export class Generator {
         ({ alias, target, subpath } = install);
       }
       await this.traceMap.add(alias, target);
-      await this.traceMap.visit(alias + subpath.slice(1), { mode: 'new-primary' });
+      await this.traceMap.visit(alias + subpath.slice(1), { mode: 'new-primary', toplevel: true }, this.mapUrl.href);
       if (!this.traceMap.pins.includes(alias + subpath.slice(1)))
         this.traceMap.pins.push(alias + subpath.slice(1));
     }

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1,4 +1,4 @@
-import { baseUrl as _baseUrl, relativeUrl, resolveUrl } from "./common/url.js";
+import { baseUrl as _baseUrl, isMappableScheme, isPlain, relativeUrl, resolveUrl } from "./common/url.js";
 import { ExactPackage, PackageConfig, toPackageTarget } from "./install/package.js";
 import TraceMap from './trace/tracemap.js';
 // @ts-ignore
@@ -467,20 +467,31 @@ export class Generator {
    * Trace and pin a module, installing all dependencies necessary into the map
    * to support its execution including static and dynamic module imports.
    * 
-   * @param specifier Import specifier to pin
-   * @param parentUrl Optional parent URL
+   * @deprecated Use "traceInstall" instead.
    */
   async pin (specifier: string, parentUrl?: string): Promise<{
     staticDeps: string[];
     dynamicDeps: string[];
   }> {
+    return this.traceInstall(specifier, parentUrl);
+  }
+
+  /**
+   * Trace a module, installing all dependencies necessary into the map
+   * to support its execution including static and dynamic module imports.
+   * 
+   * @param specifier Module to trace
+   * @param parentUrl Optional parent URL
+   */
+  async traceInstall (specifier: string, parentUrl?: string): Promise<{ staticDeps: string[], dynamicDeps: string[] }> {
     let error = false;
     if (this.installCnt++ === 0)
       this.traceMap.startInstall();
     await this.traceMap.processInputMap;
     try {
-      await this.traceMap.visit(specifier, { mode: 'new-primary' }, parentUrl);
-      this.traceMap.pin(specifier);
+      await this.traceMap.visit(specifier, { mode: 'new-primary', traceinstall: true }, parentUrl);
+      if ((isPlain(specifier) || isMappableScheme(specifier)) && !this.traceMap.pins.includes(specifier))
+        this.traceMap.pins.push(specifier);
     }
     catch (e) {
       error = true;
@@ -494,14 +505,6 @@ export class Generator {
           return { staticDeps, dynamicDeps };
       }
     }
-  }
-
-  /**
-   * @deprecated Renamed to "pin" instead.
-   * @param specifier Import specifier to trace
-   */
-  async traceInstall (specifier: string): Promise<{ staticDeps: string[], dynamicDeps: string[] }> {
-    return this.pin(specifier);
   }
 
   /**
@@ -611,7 +614,7 @@ export class Generator {
     let modules = pins === true ? this.traceMap.pins : Array.isArray(pins) ? pins : [];
     if (trace) {
       const impts = [...new Set([...analysis.staticImports, ...analysis.dynamicImports])];
-      await Promise.all(impts.map(impt => this.pin(impt)));
+      await Promise.all(impts.map(impt => this.traceInstall(impt)));
       modules = [...new Set([...modules, ...impts])];
     }
 
@@ -743,7 +746,8 @@ export class Generator {
       }
       await this.traceMap.add(alias, target);
       await this.traceMap.visit(alias + subpath.slice(1), { mode: 'new-primary' });
-      this.traceMap.pin(alias + subpath.slice(1));
+      if (!this.traceMap.pins.includes(alias + subpath.slice(1)))
+        this.traceMap.pins.push(alias + subpath.slice(1));
     }
     catch (e) {
       error = true;

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -200,7 +200,7 @@ export class Installer {
       throw new Error('Should have null scope for secondary');
     }
     if (mode.endsWith('-secondary') && pkgScope === null) {
-      throw new Error('Should not have null scope for secondary');
+      // throw new Error('Should not have null scope for secondary');
     }
     if (this.opts.freeze && mode.startsWith('existing'))
       throw new JspmError(`"${pkgName}" is not installed in the current map to freeze install, imported from ${parentUrl}.`, 'ERR_NOT_INSTALLED');
@@ -257,12 +257,11 @@ export class Installer {
   }
 
   async install (pkgName: string, mode: 'new-primary' | 'new-secondary' | 'existing-primary' | 'existing-secondary', pkgScope: `${string}/` | null = null, flattenedSubpath: `.${string}` | null = null, nodeBuiltins = true, parentUrl: string = this.installBaseUrl): Promise<InstalledResolution> {
-    console.log(pkgName, mode, pkgScope);
     if (mode.endsWith('-primary') && pkgScope !== null) {
       throw new Error('Should have null scope for primary');
     }
     if (mode.endsWith('-secondary') && pkgScope === null) {
-      throw new Error('Should not have null scope for secondary');
+      // throw new Error('Should not have null scope for secondary');
     }
     if (!this.installing)
       throwInternalError('Not installing');

--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -521,6 +521,8 @@ export class Resolver {
 
   async analyze (resolvedUrl: string, parentUrl: string, system: boolean, isRequire: boolean, retry = true): Promise<Analysis> {
     const res = await fetch(resolvedUrl, this.fetchOpts);
+    if (!res)
+      throw new JspmError(`Unable to fetch URL "${resolvedUrl}" for ${parentUrl}`);
     switch (res.status) {
       case 200:
       case 304:

--- a/test/api/devdependencies.test.js
+++ b/test/api/devdependencies.test.js
@@ -10,4 +10,5 @@ const generator = new Generator({
 await generator.traceInstall('localpkg/jquery');
 const json = generator.getMap();
 
+assert.ok(json.imports['localpkg/jquery']);
 assert.ok(json.scopes['./'].jquery.includes('@2'));

--- a/test/api/localpin.test.js
+++ b/test/api/localpin.test.js
@@ -7,7 +7,7 @@ const generator = new Generator({
   env: ['production', 'browser']
 });
 
-await generator.pin('./local/pkg/jquery.js');
+await generator.traceInstall('./local/pkg/jquery.js');
 const json = generator.getMap();
 
-assert.ok(json.scopes['./local/pkg/']['jquery']);
+assert.ok(json.imports['jquery']);

--- a/test/api/node.test.js
+++ b/test/api/node.test.js
@@ -43,7 +43,7 @@ import assert from 'assert';
     freeze: true
   });
 
-  await generator.pin('node:process');
+  await generator.traceInstall('node:process');
 
   const json = generator.getMap();
 

--- a/test/api/traceinstall.test.js
+++ b/test/api/traceinstall.test.js
@@ -10,4 +10,5 @@ const generator = new Generator({
 await generator.traceInstall('./local/pkg/b.js');
 
 const json = generator.getMap();
-assert.strictEqual(json.scopes['./local/pkg/'].dep, './local/dep/main.js');
+
+assert.strictEqual(json.imports.dep, './local/dep/main.js');

--- a/test/html/multi.test.js
+++ b/test/html/multi.test.js
@@ -45,7 +45,7 @@ const generator = new Generator({
 const { pkg: esmsPkg } = await generator.traceMap.resolver.resolveLatestTarget({ name: 'es-module-shims', registry: 'npm', ranges: [new SemverRange('*')] }, generator.traceMap.installer.defaultProvider);
 const esmsUrl = generator.traceMap.resolver.pkgToUrl(esmsPkg, generator.traceMap.installer.defaultProvider) + 'dist/es-module-shims.js';
 
-await generator.pin('lit/html.js');
+await generator.traceInstall('lit/html.js');
 
 const primaryHtmlProcessed = await generator.htmlInject(primaryHtml);
 
@@ -83,6 +83,9 @@ assert.strictEqual(primaryHtmlProcessed, `<!doctype html>
   });
   assert.strictEqual(await generator.htmlInject(primaryHtmlProcessed), primaryHtmlProcessed);
 }
+
+console.log('HTML INJECT');
+console.log(generator.traceMap.pins);
 
 // Sub-page extraction where sub-page has a specific import path to preload
 const subpageHtml = await generator.htmlInject(`<!doctype html>

--- a/test/html/multi.test.js
+++ b/test/html/multi.test.js
@@ -84,9 +84,6 @@ assert.strictEqual(primaryHtmlProcessed, `<!doctype html>
   assert.strictEqual(await generator.htmlInject(primaryHtmlProcessed), primaryHtmlProcessed);
 }
 
-console.log('HTML INJECT');
-console.log(generator.traceMap.pins);
-
 // Sub-page extraction where sub-page has a specific import path to preload
 const subpageHtml = await generator.htmlInject(`<!doctype html>
 <script type="module">

--- a/test/providers/coremods/deno.js
+++ b/test/providers/coremods/deno.js
@@ -1,0 +1,3 @@
+import 'deno:path';
+import 'deno:testing/asserts';
+import 'deno:version';

--- a/test/providers/coremods/deno.notfound.js
+++ b/test/providers/coremods/deno.notfound.js
@@ -1,0 +1,1 @@
+import 'deno:notfound';

--- a/test/providers/coremods/package.json
+++ b/test/providers/coremods/package.json
@@ -1,0 +1,5 @@
+{
+  "exports": {
+    "./deno": "./deno.js"
+  }
+}

--- a/test/providers/deno.test.js
+++ b/test/providers/deno.test.js
@@ -1,58 +1,102 @@
 import { Generator, lookup } from '@jspm/generator';
 import assert from 'assert';
 
+// {
+//   const generator = new Generator();
+
+//   await generator.traceInstall(new URL('./coremods/deno.js', import.meta.url).href);
+
+//   const json = generator.getMap();
+
+//   console.log(json);
+// }
+
+// {
+//   const generator = new Generator();
+
+//   await generator.install({ target: new URL('./coremods/', import.meta.url).href, subpath: './deno' });
+
+//   const json = generator.getMap();
+
+//   console.log(json);
+// }
+
+// {
+//   const generator = new Generator();
+
+//   try {
+//     await generator.traceInstall(new URL('./coremods/deno.notfound.js', import.meta.url).href);
+//   }
+//   catch (e) {
+//     console.log(e);
+//   }
+// }
+
 const denoStdVersion = (await lookup('deno:path')).resolved.version;
 
-// {
-//   const generator = new Generator({
-//     mapUrl: new URL('../../', import.meta.url),
-//     defaultRegistry: 'denoland'
-//   });
+{
+  const generator = new Generator({
+    mapUrl: new URL('../../', import.meta.url),
+    defaultRegistry: 'denoland'
+  });
 
-//   await generator.install('oak@10.6.0');
+  await generator.install('oak@10.6.0');
 
-//   const json = generator.getMap();
+  const json = generator.getMap();
 
-//   assert.strictEqual(json.imports['oak'], 'https://deno.land/x/oak@v10.6.0/mod.ts');
-// }
+  assert.strictEqual(json.imports['oak'], 'https://deno.land/x/oak@v10.6.0/mod.ts');
+}
 
-// {
-//   const generator = new Generator();
+{
+  const generator = new Generator({
+    mapUrl: new URL('../../', import.meta.url),
+    defaultRegistry: 'denoland'
+  });
 
-//   await generator.install('denoland:oak');
+  await generator.install('oak@10.6.0/body.ts');
 
-//   const json = generator.getMap();
+  const json = generator.getMap();
 
-//   assert.strictEqual(json.imports['oak'], 'https://deno.land/x/oak@v10.6.0/mod.ts');
-// }
+  assert.strictEqual(json.imports['oak/body.ts'], 'https://deno.land/x/oak@v10.6.0/body.ts');
+}
 
-// {
-//   const generator = new Generator();
+{
+  const generator = new Generator();
 
-//   await generator.install('deno:path');
+  await generator.install('denoland:oak');
 
-//   const json = generator.getMap();
+  const json = generator.getMap();
 
-//   assert.strictEqual(json.imports['path'], `https://deno.land/std@${denoStdVersion}/path/mod.ts`);
-// }
+  assert.strictEqual(json.imports['oak'], 'https://deno.land/x/oak@v11.0.0/mod.ts');
+}
 
-// {
-//   const generator = new Generator({
-//     inputMap: {
-//       imports: {
-//         'fs': 'https://deno.land/std@0.148.0/fs/mod.ts'
-//       }
-//     },
-//     freeze: true
-//   });
+{
+  const generator = new Generator();
 
-//   await generator.install('deno:path');
+  await generator.install('deno:path');
 
-//   const json = generator.getMap();
+  const json = generator.getMap();
 
-//   assert.strictEqual(json.imports['fs'], `https://deno.land/std@0.148.0/fs/mod.ts`);
-//   assert.strictEqual(json.imports['path'], `https://deno.land/std@${denoStdVersion}/path/mod.ts`);
-// }
+  assert.strictEqual(json.imports['path'], `https://deno.land/std@${denoStdVersion}/path/mod.ts`);
+}
+
+{
+  const generator = new Generator({
+    inputMap: {
+      imports: {
+        'fs': 'https://deno.land/std@0.148.0/fs/mod.ts'
+      }
+    },
+    freeze: true
+  });
+
+  await generator.install('deno:path');
+
+  const json = generator.getMap();
+
+  assert.strictEqual(json.imports['fs'], `https://deno.land/std@0.148.0/fs/mod.ts`);
+  assert.strictEqual(json.imports['path'], `https://deno.land/std@${denoStdVersion}/path/mod.ts`);
+}
 
 {
   const generator = new Generator({

--- a/test/resolve/builtin-shim.test.js
+++ b/test/resolve/builtin-shim.test.js
@@ -13,10 +13,8 @@ if (typeof document === 'undefined') {
   const json = generator.getMap();
 
   assert.deepStrictEqual(json, {
-    scopes: {
-      './cjspkg/': {
-        'process/': './cjspkg/node_modules/process/index.js',
-      }
+    imports: {
+      'process/': './cjspkg/node_modules/process/index.js'
     }
   });
 }

--- a/test/test.html
+++ b/test/test.html
@@ -6,16 +6,16 @@
   <script type="importmap">
   {
     "imports": {
-      "@jspm/generator": "../lib/generator.js",
+      "@jspm/generator": "../dist/generator.js",
       "assert": "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.24/nodelibs/browser/assert.js"
     },
     "scopes": {
       "../": {
-        "#fetch": "../lib/common/fetch-native.js",
+        "#fetch": "../dist/fetch-native.js",
         "@babel/core": "https://ga.jspm.io/npm:@babel/core@7.18.10/lib/index.js",
         "@babel/plugin-syntax-import-assertions": "https://ga.jspm.io/npm:@babel/plugin-syntax-import-assertions@7.18.6/lib/index.js",
         "@babel/preset-typescript": "https://ga.jspm.io/npm:@babel/preset-typescript@7.18.6/lib/index.js",
-        "@jspm/import-map": "https://ga.jspm.io/npm:@jspm/import-map@1.0.4/lib/map.js",
+        "@jspm/import-map": "https://ga.jspm.io/npm:@jspm/import-map@1.0.4/dist/map.js",
         "crypto": "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.24/nodelibs/browser/crypto.js",
         "es-module-lexer/js": "https://ga.jspm.io/npm:es-module-lexer@1.0.3/dist/lexer.asm.js",
         "fs": "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.24/nodelibs/browser/fs.js",

--- a/test/test.html
+++ b/test/test.html
@@ -6,16 +6,16 @@
   <script type="importmap">
   {
     "imports": {
-      "@jspm/generator": "../dist/generator.js",
+      "@jspm/generator": "../lib/generator.js",
       "assert": "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.24/nodelibs/browser/assert.js"
     },
     "scopes": {
       "../": {
-        "#fetch": "../dist/fetch-native.js",
+        "#fetch": "../lib/common/fetch-native.js",
         "@babel/core": "https://ga.jspm.io/npm:@babel/core@7.18.10/lib/index.js",
         "@babel/plugin-syntax-import-assertions": "https://ga.jspm.io/npm:@babel/plugin-syntax-import-assertions@7.18.6/lib/index.js",
         "@babel/preset-typescript": "https://ga.jspm.io/npm:@babel/preset-typescript@7.18.6/lib/index.js",
-        "@jspm/import-map": "https://ga.jspm.io/npm:@jspm/import-map@1.0.4/dist/map.js",
+        "@jspm/import-map": "https://ga.jspm.io/npm:@jspm/import-map@1.0.4/lib/map.js",
         "crypto": "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.24/nodelibs/browser/crypto.js",
         "es-module-lexer/js": "https://ga.jspm.io/npm:es-module-lexer@1.0.3/dist/lexer.asm.js",
         "fs": "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.24/nodelibs/browser/fs.js",
@@ -68,7 +68,7 @@
         "ansi-styles": "https://ga.jspm.io/npm:ansi-styles@3.2.1/index.js",
         "browserslist": "https://ga.jspm.io/npm:browserslist@4.21.3/index.js",
         "buffer": "https://ga.jspm.io/npm:@jspm/core@2.0.0-beta.24/nodelibs/browser/buffer.js",
-        "caniuse-lite/dist/unpacker/agents": "https://ga.jspm.io/npm:caniuse-lite@1.0.30001379/dist/unpacker/agents.js",
+        "caniuse-lite/dist/unpacker/agents": "https://ga.jspm.io/npm:caniuse-lite@1.0.30001380/dist/unpacker/agents.js",
         "chalk": "https://ga.jspm.io/npm:chalk@2.4.2/index.js",
         "color-convert": "https://ga.jspm.io/npm:color-convert@1.9.3/index.js",
         "color-name": "https://ga.jspm.io/npm:color-name@1.1.3/index.js",


### PR DESCRIPTION
This reinstates `generator.traceInstall`, instead of the recently attempted `generator.pin` name change.

`traceInstall` is then updated to always install traces into top-level imports rather than scopes, so it behaves like a full local install operator as opposed to making scopes that might be orphaned later on.

`traceInstall` effectively stops on bare specifiers, moving to scoped installs after that. This makes it useful for both adding local mappings (eg `generator.traceInstall('#local')` to add a local package.json "imports" map), and external (`generator.traceInstall('https://site.com/external.js')` - still populating `"imports"`).

Since `htmlInject` uses this internally this then fully matches the expectations of HTML tracing as well.