### PR TITLE
feat: cachefly CDN layer

### DIFF
--- a/src/providers/jspm.ts
+++ b/src/providers/jspm.ts
@@ -8,13 +8,8 @@ import { Resolver } from "../trace/resolver.js";
 // @ts-ignore
 import { fetch } from '#fetch';
 
-export function setBeta () {
-  curCdnUrl= cacheFlyCdnUrl;
-}
-
 const cdnUrl = 'https://ga.jspm.io/';
 const cacheFlyCdnUrl = 'https://jspm001.cachefly.net/';
-let curCdnUrl = cdnUrl;
 const systemCdnUrl = 'https://ga.system.jspm.io/';
 const apiUrl = 'https://api.jspm.io/';
 
@@ -63,16 +58,16 @@ export function clearResolveCache () {
 
 async function checkBuildOrError (pkg: ExactPackage, fetchOpts: any): Promise<boolean> {
   const pkgStr = pkgToStr(pkg);
-  const pjsonRes = await fetch(`${curCdnUrl}${pkgStr}/package.json`, fetchOpts);
+  const pjsonRes = await fetch(`${cdnUrl}${pkgStr}/package.json`, fetchOpts);
   if (pjsonRes.ok)
     return true;
   // no package.json! Check if there's a build error:
-  const errLogRes = await fetch(`${curCdnUrl}${pkgStr}/_error.log`, fetchOpts);
+  const errLogRes = await fetch(`${cdnUrl}${pkgStr}/_error.log`, fetchOpts);
   if (errLogRes.ok) {
     const errLog = await errLogRes.text();
     throw new JspmError(`Resolved dependency ${pkgStr} with error:\n\n${errLog}\nPlease post an issue at jspm/project on GitHub, or by following the link below:\n\nhttps://github.com/jspm/project/issues/new?title=CDN%20build%20error%20for%20${encodeURIComponent(pkg.name + '@' + pkg.version)}&body=_Reporting%20CDN%20Build%20Error._%0A%0A%3C!--%20%20No%20further%20description%20necessary,%20just%20click%20%22Submit%20new%20issue%22%20--%3E`);
   }
-  console.error(`Unable to request ${curCdnUrl}${pkgStr}/package.json - ${pjsonRes.status} ${pjsonRes.statusText || 'returned'}`);
+  console.error(`Unable to request ${cdnUrl}${pkgStr}/package.json - ${pjsonRes.status} ${pjsonRes.statusText || 'returned'}`);
   return false;
 }
 
@@ -180,7 +175,7 @@ export async function resolveLatestTarget (this: Resolver, target: LatestPackage
 }
 
 function pkgToLookupUrl (pkg: ExactPackage, edge = false) {
-  return `${curCdnUrl}${pkg.registry}:${pkg.name}${pkg.version ? '@' + pkg.version : edge ? '@' : ''}`;
+  return `${cdnUrl}${pkg.registry}:${pkg.name}${pkg.version ? '@' + pkg.version : edge ? '@' : ''}`;
 }
 async function lookupRange (this: Resolver, registry: string, name: string, range: string, unstable: boolean, parentUrl?: string): Promise<ExactPackage | null> {
   const res = await fetch(pkgToLookupUrl({ registry, name, version: range }, unstable), this.fetchOpts);

--- a/src/providers/jspm.ts
+++ b/src/providers/jspm.ts
@@ -8,7 +8,13 @@ import { Resolver } from "../trace/resolver.js";
 // @ts-ignore
 import { fetch } from '#fetch';
 
+export function setBeta () {
+  curCdnUrl= cacheFlyCdnUrl;
+}
+
 const cdnUrl = 'https://ga.jspm.io/';
+const cacheFlyCdnUrl = 'https://jspm001.cachefly.net/';
+let curCdnUrl = cdnUrl;
 const systemCdnUrl = 'https://ga.system.jspm.io/';
 const apiUrl = 'https://api.jspm.io/';
 
@@ -16,7 +22,7 @@ const BUILD_POLL_TIME = 5 * 60 * 1000;
 const BUILD_POLL_INTERVAL = 5 * 1000;
 
 export function pkgToUrl (pkg: ExactPackage, layer: string): `${string}/` {
-  return `${layer === 'system' ? systemCdnUrl : cdnUrl}${pkgToStr(pkg)}/`;
+  return `${layer === 'system' ? systemCdnUrl : layer === 'cachefly' ? cacheFlyCdnUrl : cdnUrl}${pkgToStr(pkg)}/`;
 }
 
 const exactPkgRegEx = /^(([a-z]+):)?((?:@[^/\\%@]+\/)?[^./\\%@][^/\\%@]*)@([^\/]+)(\/.*)?$/;
@@ -25,11 +31,13 @@ export function parseUrlPkg (url: string): { pkg: ExactPackage, layer: string, s
   let layer: string;
   if (url.startsWith(cdnUrl))
     layer = 'default';
+  else if (url.startsWith(cacheFlyCdnUrl))
+    layer = 'cachefly';
   else if (url.startsWith(systemCdnUrl))
     layer = 'system';
   else
     return;
-  const [,, registry, name, version] = url.slice((layer === 'default' ? cdnUrl : systemCdnUrl).length).match(exactPkgRegEx) || [];
+  const [,, registry, name, version] = url.slice((layer === 'default' ? cdnUrl : layer === 'cachefly' ? cacheFlyCdnUrl : systemCdnUrl).length).match(exactPkgRegEx) || [];
   if (registry && name && version) {
     if (registry === 'npm' && name === '@jspm/core' && url.includes('/nodelibs/')) {
       subpath = `./nodelibs/${url.slice(url.indexOf('/nodelibs/') + 10).split('/')[1]}`;
@@ -55,16 +63,16 @@ export function clearResolveCache () {
 
 async function checkBuildOrError (pkg: ExactPackage, fetchOpts: any): Promise<boolean> {
   const pkgStr = pkgToStr(pkg);
-  const pjsonRes = await fetch(`${cdnUrl}${pkgStr}/package.json`, fetchOpts);
+  const pjsonRes = await fetch(`${curCdnUrl}${pkgStr}/package.json`, fetchOpts);
   if (pjsonRes.ok)
     return true;
   // no package.json! Check if there's a build error:
-  const errLogRes = await fetch(`${cdnUrl}${pkgStr}/_error.log`, fetchOpts);
+  const errLogRes = await fetch(`${curCdnUrl}${pkgStr}/_error.log`, fetchOpts);
   if (errLogRes.ok) {
     const errLog = await errLogRes.text();
     throw new JspmError(`Resolved dependency ${pkgStr} with error:\n\n${errLog}\nPlease post an issue at jspm/project on GitHub, or by following the link below:\n\nhttps://github.com/jspm/project/issues/new?title=CDN%20build%20error%20for%20${encodeURIComponent(pkg.name + '@' + pkg.version)}&body=_Reporting%20CDN%20Build%20Error._%0A%0A%3C!--%20%20No%20further%20description%20necessary,%20just%20click%20%22Submit%20new%20issue%22%20--%3E`);
   }
-  console.error(`Unable to request ${cdnUrl}${pkgStr}/package.json - ${pjsonRes.status} ${pjsonRes.statusText || 'returned'}`);
+  console.error(`Unable to request ${curCdnUrl}${pkgStr}/package.json - ${pjsonRes.status} ${pjsonRes.statusText || 'returned'}`);
   return false;
 }
 
@@ -172,7 +180,7 @@ export async function resolveLatestTarget (this: Resolver, target: LatestPackage
 }
 
 function pkgToLookupUrl (pkg: ExactPackage, edge = false) {
-  return `${cdnUrl}${pkg.registry}:${pkg.name}${pkg.version ? '@' + pkg.version : edge ? '@' : ''}`;
+  return `${curCdnUrl}${pkg.registry}:${pkg.name}${pkg.version ? '@' + pkg.version : edge ? '@' : ''}`;
 }
 async function lookupRange (this: Resolver, registry: string, name: string, range: string, unstable: boolean, parentUrl?: string): Promise<ExactPackage | null> {
   const res = await fetch(pkgToLookupUrl({ registry, name, version: range }, unstable), this.fetchOpts);

--- a/test/providers/jspm.cachefly.test.js
+++ b/test/providers/jspm.cachefly.test.js
@@ -1,0 +1,15 @@
+import { Generator } from '@jspm/generator';
+import assert from 'assert';
+
+const generator = new Generator({
+  defaultProvider: 'jspm.cachefly'
+});
+
+await generator.install('lit@2.0.0-rc.1');
+const json = generator.getMap();
+
+assert.strictEqual(json.imports.lit, 'https://jspm001.cachefly.net/npm:lit@2.0.0-rc.1/index.js');
+const scope = json.scopes['https://jspm001.cachefly.net/'];
+assert.ok(scope['@lit/reactive-element']);
+assert.ok(scope['lit-element/lit-element.js']);
+assert.ok(scope['lit-html']);


### PR DESCRIPTION
This adds support for an experimental CacheFly CDN layer, which can be opted-in to via the configuration:

```js
import { Generator } from '@jspm/generator';

const generator = new Generator({
  defaultProvider: 'jspm.cachefly'
});
```

This will allow us to assess the performance of this CDN switch, before it applies to the entire CDN.