### PR TITLE
chore: fix dependency audit and silence deno tests

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5273,9 +5273,9 @@
       }
     },
     "node_modules/undici": {
-      "version": "5.18.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.18.0.tgz",
-      "integrity": "sha512-1iVwbhonhFytNdg0P4PqyIAXbdlVZVebtPDvuM36m66mRw4OGrCm2MYynJv/UENFLdP13J1nPVQzVE2zTs1OeA==",
+      "version": "5.20.0",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-5.20.0.tgz",
+      "integrity": "sha512-J3j60dYzuo6Eevbawwp1sdg16k5Tf768bxYK4TUJRH7cBM4kFCbf3mOnM/0E3vQYXvpxITbbWmBafaDbxLDz3g==",
       "dependencies": {
         "busboy": "^1.6.0"
       },

--- a/test/deno.js
+++ b/test/deno.js
@@ -18,7 +18,7 @@ export function denoExec(map, source) {
   execSync(
     `${
       process.env.DENO_BIN || "deno"
-    } run --reload --unstable --no-check --allow-all --import-map=${tmpMap} ${tmpSrc}`,
+    } run --quiet --reload --unstable --no-check --allow-all --import-map=${tmpMap} ${tmpSrc}`,
     { stdio: "inherit" }
   );
 }


### PR DESCRIPTION
Minor stuff done while digging into an importmap bug. Currently there's a test
failing because a newly released version of a transitive dependency is broken,
nothing we can do about it until they release a fix.
