### PR TITLE
feat: translate locks to default provider during input map extraction

### DIFF
--- a/chompfile.toml
+++ b/chompfile.toml
@@ -47,21 +47,31 @@ inlineSourcesContent = false
 'jsc.target' = 'es2019'
 
 [[task]]
-name = 'test:unit'
-dep = 'unit:'
-
-[[task]]
 name = 'test'
 serial = true
 deps = [
     'test:unit',
+    'test:integration',
     'test:browser',
 ]
 
 [[task]]
+name = 'test:unit'
+dep= 'unit:'
+
+[[task]]
 name = 'unit:#'
+deps = ['lib/##.test.js', 'lib']
+run = 'node -C source --enable-source-maps $DEP'
+
+[[task]]
+name = 'test:integration'
+dep = 'integration:'
+
+
+[[task]]
+name = 'integration:#'
 deps = ['test/##.test.js', 'lib']
-display = 'dot'
 run = 'node -C source --enable-source-maps $DEP'
 
 [[task]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -18,7 +18,7 @@
         "ipfs-client": "^0.9.2",
         "make-fetch-happen": "^8.0.14",
         "rimraf": "^4.1.2",
-        "sver": "^1.8.3"
+        "sver": "^1.8.4"
       },
       "devDependencies": {
         "@swc/cli": "^0.1.61",
@@ -5003,9 +5003,9 @@
       }
     },
     "node_modules/sver": {
-      "version": "1.8.3",
-      "resolved": "https://registry.npmjs.org/sver/-/sver-1.8.3.tgz",
-      "integrity": "sha512-Qn39MggkkPw3d1BACWNV+Njwt9L0znk8oNW8NlJv4lWTEseMzbjHzunnPJDnt/5mfLHV5kt5JkMTqPbMVrg2CA==",
+      "version": "1.8.4",
+      "resolved": "https://registry.npmjs.org/sver/-/sver-1.8.4.tgz",
+      "integrity": "sha512-71o1zfzyawLfIWBOmw8brleKyvnbn73oVHNCsu51uPMz/HWiKkkXsI31JjHW5zqXEqnPYkIiHd8ZmL7FCimLEA==",
       "optionalDependencies": {
         "semver": "^6.3.0"
       }

--- a/package.json
+++ b/package.json
@@ -28,12 +28,17 @@
     }
   },
   "exports": {
-    "source": {
-      "deno": "./lib/generator-deno.js",
-      "default": "./lib/generator.js"
+    ".": {
+      "source": {
+        "deno": "./lib/generator-deno.js",
+        "default": "./lib/generator.js"
+      },
+      "deno": "./dist/generator-deno.js",
+      "default": "./dist/generator.js"
     },
-    "deno": "./dist/generator-deno.js",
-    "default": "./dist/generator.js"
+    "./*.js": {
+      "source": "./lib/*.js"
+    }
   },
   "dependencies": {
     "@babel/core": "^7.20.12",
@@ -45,7 +50,7 @@
     "ipfs-client": "^0.9.2",
     "make-fetch-happen": "^8.0.14",
     "rimraf": "^4.1.2",
-    "sver": "^1.8.3"
+    "sver": "^1.8.4"
   },
   "devDependencies": {
     "@swc/cli": "^0.1.61",

--- a/src/common/b64.ts
+++ b/src/common/b64.ts
@@ -1,0 +1,15 @@
+export function encodeBase64(data: string): string {
+  if (typeof window !== "undefined") {
+    return window.btoa(data);
+  }
+
+  return Buffer.from(data).toString("base64");
+}
+
+export function decodeBase64(data: string): string {
+  if (typeof window !== "undefined") {
+    return window.atob(data);
+  }
+
+  return Buffer.from(data, "base64").toString("utf8");
+}

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -439,7 +439,10 @@ export class Generator {
 
     // The node_modules provider is special, because it needs to be rooted to
     // perform resolutions against the local node_modules directory:
-    const nmProvider = nodemodules.createProvider(this.baseUrl.href);
+    const nmProvider = nodemodules.createProvider(
+      this.baseUrl.href,
+      defaultProvider === "nodemodules"
+    );
     resolver.addCustomProvider("nodemodules", nmProvider);
 
     // Initialise the tracer:

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -6,11 +6,11 @@ import { ExactPackage, newPackageTarget, PackageTarget } from "./package.js";
 import { JspmError, throwInternalError } from "../common/err.js";
 import {
   getFlattenedResolution,
-  getInstallsFor,
+  getConstraintFor,
   getResolution,
   InstalledResolution,
   LockResolutions,
-  PackageInstall,
+  PackageConstraint,
   setConstraint,
   setResolution,
   VersionConstraints,
@@ -248,10 +248,10 @@ export class Installer {
     );
 
     const pkgUrl = await this.resolver.pkgToUrl(latestPkg, provider);
-    const installed = getInstallsFor(
-      this.constraints,
+    const installed = getConstraintFor(
+      latestPkg.name,
       latestPkg.registry,
-      latestPkg.name
+      this.constraints
     );
     if (
       !this.opts.freeze &&
@@ -511,7 +511,7 @@ export class Installer {
   private tryUpgradeAllTo(
     pkg: ExactPackage,
     pkgUrl: `${string}/`,
-    installed: PackageInstall[]
+    installed: PackageConstraint[]
   ): boolean {
     const pkgVersion = new Semver(pkg.version);
 
@@ -544,7 +544,7 @@ export class Installer {
   private upgradeSupportedTo(
     pkg: ExactPackage,
     pkgUrl: `${string}/`,
-    installed: PackageInstall[]
+    installed: PackageConstraint[]
   ) {
     const pkgVersion = new Semver(pkg.version);
     for (const { alias, pkgScope, ranges } of installed) {

--- a/src/install/lock.test.ts
+++ b/src/install/lock.test.ts
@@ -1,0 +1,54 @@
+import {
+  ExactPackage,
+  PackageTarget,
+} from "@jspm/generator/install/package.js";
+import {
+  changeProvider,
+  changeRegistry,
+} from "@jspm/generator/install/lock.js";
+import { Provider } from "@jspm/generator/providers/index.js";
+import { Generator } from "@jspm/generator";
+import { encodeBase64 } from "@jspm/generator/common/b64.js";
+import { strictEqual } from "assert";
+
+const rootUrl = new URL("../../", import.meta.url);
+const g = new Generator({
+  mapUrl: rootUrl.href,
+});
+const r = g.traceMap.resolver;
+
+{
+  async function testForRegistry(
+    registry: string,
+    n: string,
+    v: string,
+    isNull: boolean = false
+  ) {
+    const pkg: ExactPackage = {
+      name: n,
+      version: v,
+      registry,
+    };
+
+    // Should have switched to "npm" registry, as that's what jspm.io tracks:
+    const provider = { provider: "jspm.io", layer: "default" };
+    const res = await changeProvider(pkg, provider, r, rootUrl);
+    if (isNull) {
+      strictEqual(res, null);
+    } else {
+      strictEqual(res.name, "chalk");
+      strictEqual(res.registry, "npm");
+      strictEqual(res.version, "4.1.2");
+    }
+  }
+
+  // Must match the version of "chalk" installed locally!
+  await testForRegistry("npm", "chalk", "4.1.2");
+  await testForRegistry("deno", "chalk", "4.1.2", true);
+  await testForRegistry("denoland", "chalk", "4.1.2", true);
+  await testForRegistry(
+    "node_modules",
+    "chalk",
+    encodeBase64(new URL("./node_modules/chalk/", rootUrl).href)
+  );
+}

--- a/src/install/lock.test.ts
+++ b/src/install/lock.test.ts
@@ -1,5 +1,6 @@
 import {
   ExactPackage,
+  ExactModule,
   PackageTarget,
 } from "@jspm/generator/install/package.js";
 import {
@@ -18,27 +19,32 @@ const g = new Generator({
 const r = g.traceMap.resolver;
 
 {
+  /* changeProvider tests */
   async function testForRegistry(
     registry: string,
     n: string,
     v: string,
     isNull: boolean = false
   ) {
-    const pkg: ExactPackage = {
-      name: n,
-      version: v,
-      registry,
+    const mdl: ExactModule = {
+      pkg: {
+        name: n,
+        version: v,
+        registry,
+      },
+      subpath: null,
+      source: { provider: "test", layer: "default" },
     };
 
     // Should have switched to "npm" registry, as that's what jspm.io tracks:
     const provider = { provider: "jspm.io", layer: "default" };
-    const res = await changeProvider(pkg, provider, r, rootUrl);
+    const res = await changeProvider(mdl, provider, r, rootUrl);
     if (isNull) {
       strictEqual(res, null);
     } else {
-      strictEqual(res.name, "chalk");
-      strictEqual(res.registry, "npm");
-      strictEqual(res.version, "4.1.2");
+      strictEqual(res.pkg.name, "chalk");
+      strictEqual(res.pkg.registry, "npm");
+      strictEqual(res.pkg.version, "4.1.2");
     }
   }
 

--- a/src/install/lock.ts
+++ b/src/install/lock.ts
@@ -599,7 +599,10 @@ export async function changeProvider(
   const fromNodeModules = pkg.registry === "node_modules";
   const toNodeModules = provider === "nodemodules";
   if (fromNodeModules === toNodeModules) {
-    return mdl;
+    return {
+      ...mdl,
+      source: { provider, layer },
+    };
   }
 
   const target = await packageTargetFromExact(pkg, resolver);
@@ -652,19 +655,4 @@ async function resolveTargetPkg(
   }
 
   return { parsedTarget, pkgUrl, subpath };
-}
-
-async function resolveScope(
-  scopeUrl: string,
-  mapUrl: URL,
-  rootUrl: URL,
-  resolver: Resolver
-) {
-  const resolvedScopeUrl = resolveUrl(scopeUrl, mapUrl, rootUrl) ?? scopeUrl;
-  const scopePkgUrl = await resolver.getPackageBase(resolvedScopeUrl);
-
-  // We automatically translate all scopes to the current provider:
-  // TODO
-
-  return { resolvedScopeUrl, scopePkgUrl };
 }

--- a/src/install/package.ts
+++ b/src/install/package.ts
@@ -59,8 +59,8 @@ export interface PackageConfig {
  * such as npm or deno.
  */
 export interface ExactPackage {
-  registry: string;
   name: string;
+  registry: string;
   version: string;
 }
 

--- a/src/install/package.ts
+++ b/src/install/package.ts
@@ -5,7 +5,7 @@ import sver from "sver";
 const { SemverRange } = sver;
 // @ts-ignore
 import convertRange from "sver/convert-range.js";
-import { InstallTarget } from "./installer.js";
+import { InstallTarget, PackageProvider } from "./installer.js";
 import { Resolver } from "../trace/resolver.js";
 import { builtinSchemes } from "../providers/index.js";
 import { Install } from "../generator.js";
@@ -62,6 +62,16 @@ export interface ExactPackage {
   name: string;
   registry: string;
   version: string;
+}
+
+/**
+ * ExactModule pins down an exact version of a module in a package that can be
+ * served by a PackageProvider.
+ */
+export interface ExactModule {
+  pkg: ExactPackage;
+  subpath: `./${string}` | null;
+  source: PackageProvider;
 }
 
 /**

--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -3,6 +3,7 @@ import {
   PackageConfig,
   PackageTarget,
   ExportsTarget,
+  ExactModule,
 } from "../install/package.js";
 import { JspmError } from "../common/err.js";
 import { Log } from "../common/log.js";
@@ -92,23 +93,24 @@ export class Resolver {
     this.providers = Object.assign({}, this.providers, { [name]: provider });
   }
 
-  async providerForUrl(url: string): Promise<Provider | null> {
+  async providerNameForUrl(url: string): Promise<string | null> {
     for (const name of Object.keys(this.providers)) {
       const provider = this.providers[name];
       if (
         (provider.ownsUrl && provider.ownsUrl.call(this, url)) ||
         provider.parseUrlPkg.call(this, url)
       ) {
-        return provider;
+        return name;
       }
     }
   }
 
-  async parseUrlPkg(url: string): Promise<{
-    pkg: ExactPackage;
-    subpath: null | `./${string}`;
-    source: { layer: string; provider: string };
-  } | null> {
+  async providerForUrl(url: string): Promise<Provider | null> {
+    const name = await this.providerNameForUrl(url);
+    return name ? this.providers[name] : null;
+  }
+
+  async parseUrlPkg(url: string): Promise<ExactModule | null> {
     for (const provider of Object.keys(this.providers)) {
       const providerInstance = this.providers[provider];
       const result = providerInstance.parseUrlPkg.call(this, url);

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -165,7 +165,8 @@ export default class TraceMap {
         mapUrl,
         rootUrl,
         this.installer.defaultRegistry,
-        this.resolver
+        this.resolver,
+        this.installer.defaultProvider
       );
       this.inputMap.extend(maps);
       mergeLocks(this.installer.installs, locks);


### PR DESCRIPTION
Fixes #249. When extracting locks from the input map the generator now automatically
translates any locks from a non-default provider to the default provider, in a
best-effort fashion.

This makes swapping providers have much more intuitive behaviour, I'll link a
screenshot. If we solve #250 to get rid of the trailing-slash mappings, then
provider swapping will be super smooth.
