### PR TITLE
fix: generate type declaration files and map to them in package.json

### DIFF
--- a/chompfile.toml
+++ b/chompfile.toml
@@ -5,9 +5,13 @@ extensions = ['chomp@0.1:swc', 'chomp@0.1:rollup', 'chomp@0.1:prettier']
 default-task = 'build'
 
 [[task]]
+target = 'lib'
+deps = ['lib/**/*.js']
+
+[[task]]
 name = 'build'
 target = 'dist'
-deps = ['lib', 'npm:install']
+deps = ['lib', 'npm:install', 'build:dec']
 template = 'rollup'
 [task.template-options]
 input = [
@@ -24,8 +28,20 @@ clear-dir = true
 dir = 'dist'
 
 [[task]]
-target = 'lib'
-deps = ['lib/**/*.js']
+name = 'build:ts'
+target = 'lib/##.js'
+deps = ['src/##.ts']
+template = 'swc'
+[task.template-options.config]
+inlineSourcesContent = false
+'jsc.target' = 'es2019'
+
+# TODO: We should emit declaration files with swc once they support it.
+#       See: https://github.com/swc-project/swc/issues/657
+[[task]]
+name = 'build:dec'
+deps = ['src/**/*.ts']
+run = 'tsc --emitDeclarationOnly'
 
 [[task]]
 target = 'lib/version.js'
@@ -38,25 +54,16 @@ run = '''
 '''
 
 [[task]]
-name = 'build:ts'
-target = 'lib/##.js'
-deps = ['src/##.ts']
-template = 'swc'
-[task.template-options.config]
-inlineSourcesContent = false
-'jsc.target' = 'es2019'
-
-[[task]]
-name = 'test:unit'
-dep = 'unit:'
-
-[[task]]
 name = 'test'
 serial = true
 deps = [
     'test:unit',
     'test:browser',
 ]
+
+[[task]]
+name = 'test:unit'
+dep = 'unit:'
 
 [[task]]
 name = 'unit:#'
@@ -107,10 +114,10 @@ run = '''
 [[task]]
 name = 'prettier'
 template = 'prettier'
-deps = ['src/**/*', 'src/*', 'test/**/*', 'test/*']
+deps = ['src/**/*.ts', 'test/**/*.ts']
 [task.template-options]
 ignore-path = '.prettierignore'
-files = 'src/**/*.ts src/*.ts test/**/*.ts test/*'
+files = 'src/**/*.ts test/**/*.ts'
 loglevel = 'warn'
 
 [[task]]

--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,7 @@
         "@babel/core": "^7.20.12",
         "@babel/plugin-syntax-import-assertions": "^7.20.0",
         "@babel/preset-typescript": "^7.18.6",
-        "@jspm/import-map": "^1.0.4",
+        "@jspm/import-map": "^1.0.5",
         "abort-controller": "^3.0.0",
         "es-module-lexer": "^1.1.1",
         "ipfs-client": "^0.9.2",
@@ -32,7 +32,8 @@
         "mocha": "^9.2.2",
         "open": "^8.4.1",
         "prettier": "^2.8.4",
-        "rollup": "^2.79.1"
+        "rollup": "^2.79.1",
+        "typescript": "^4.9.5"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -5126,6 +5127,19 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
       "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
+    },
+    "node_modules/typescript": {
+      "version": "4.9.5",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-4.9.5.tgz",
+      "integrity": "sha512-1FXk9E2Hm+QzZQ7z+McJiHL4NW1F2EzMu9Nq9i3zAaGqibafqYwCVU6WyWAuyQRRzOlxou8xZSyXLEN8oKj24g==",
+      "dev": true,
+      "bin": {
+        "tsc": "bin/tsc",
+        "tsserver": "bin/tsserver"
+      },
+      "engines": {
+        "node": ">=4.2.0"
+      }
     },
     "node_modules/uint8arraylist": {
       "version": "2.4.3",

--- a/package.json
+++ b/package.json
@@ -3,7 +3,7 @@
   "description": "Package Import Map Generation Tool",
   "license": "MIT",
   "version": "1.0.4",
-  "types": "src/generator.ts",
+  "types": "lib/generator.d.ts",
   "type": "module",
   "scripts": {
     "prepublishOnly": "chomp build"
@@ -28,6 +28,10 @@
     }
   },
   "exports": {
+    "types": {
+      "deno": "./lib/generator-deno.d.ts",
+      "default": "./lib/generator.d.ts"
+    },
     "source": {
       "deno": "./lib/generator-deno.js",
       "default": "./lib/generator.js"
@@ -39,7 +43,7 @@
     "@babel/core": "^7.20.12",
     "@babel/plugin-syntax-import-assertions": "^7.20.0",
     "@babel/preset-typescript": "^7.18.6",
-    "@jspm/import-map": "^1.0.4",
+    "@jspm/import-map": "^1.0.5",
     "abort-controller": "^3.0.0",
     "es-module-lexer": "^1.1.1",
     "ipfs-client": "^0.9.2",
@@ -59,7 +63,8 @@
     "mocha": "^9.2.2",
     "open": "^8.4.1",
     "prettier": "^2.8.4",
-    "rollup": "^2.79.1"
+    "rollup": "^2.79.1",
+    "typescript": "^4.9.5"
   },
   "files": [
     "dist",

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,8 +13,7 @@
     "strictBindCallApply": true
   },
   "include": [
-    "src/*.ts",
-    "src**/*.ts",
+    "src/**/*.ts",
     "src/script-lexer.js",
     "src/api.js"
   ],

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,11 +8,13 @@
     "sourceMap": true,
     "outDir": "lib",
     "declaration": true,
+    "declarationDir": "lib",
     "removeComments": false,
     "strictBindCallApply": true
   },
   "include": [
-    "src/**/*.ts",
+    "src/*.ts",
+    "src**/*.ts",
     "src/script-lexer.js",
     "src/api.js"
   ],


### PR DESCRIPTION
Fixes #252. We need to do this in `@jspm/import-map` as well, it's suffering from
the same packaging issue.
