### PR TITLE
feat: only throw when tracing cjs modules that use cjs globals

### DIFF
--- a/src/trace/analysis.ts
+++ b/src/trace/analysis.ts
@@ -4,6 +4,9 @@ export interface Analysis {
   cjsLazyDeps: string[] | null;
   format: "esm" | "commonjs" | "system" | "json" | "typescript";
   size: number;
+
+  // for commonjs format, true iff the module uses a CJS-only global
+  usesCjs?: boolean;
 }
 
 export { createTsAnalysis } from "./ts.js";

--- a/test/resolve/unused-cjs.test.js
+++ b/test/resolve/unused-cjs.test.js
@@ -1,0 +1,17 @@
+import { Generator } from "@jspm/generator";
+import assert from "assert";
+
+const generator = new Generator({
+  mapUrl: import.meta.url,
+})
+
+// Should not throw, index file doesn't use CJS:
+await generator.install("./unusedcjspkg");
+
+// Should throw, uses module global:
+await (async() => {
+  try {
+    await generator.install("./unusedcjspkg/cjs.js");
+    assert(false);
+  } catch {}
+})();

--- a/test/resolve/unusedcjspkg/cjs.js
+++ b/test/resolve/unusedcjspkg/cjs.js
@@ -1,0 +1,7 @@
+// This file actually uses CJS globals:
+function test() {
+  module.exports = { a: "b" };
+}
+
+test();
+require("asdf");

--- a/test/resolve/unusedcjspkg/index.js
+++ b/test/resolve/unusedcjspkg/index.js
@@ -1,0 +1,6 @@
+// This file is in a CommonJS resolution context (there's no `"type": "module"`
+// field in the package.json), but doesn't actually use any CommonJS globals,
+// so we should be able to link this without enabling CJS explicitly:
+some = 0;
+unbound = 1;
+globals = 2;

--- a/test/resolve/unusedcjspkg/index.js
+++ b/test/resolve/unusedcjspkg/index.js
@@ -4,3 +4,4 @@
 some = 0;
 unbound = 1;
 globals = 2;
+var require = NOT_REQUIRE;

--- a/test/resolve/unusedcjspkg/package.json
+++ b/test/resolve/unusedcjspkg/package.json
@@ -1,0 +1,3 @@
+{
+  "main": "index.js"
+}


### PR DESCRIPTION
See #259. Currently the generator is as strict as the Node.js resolver when it
comes to tracing CommonJS modules. For our purposes it only matters if the
traced CJS module uses CJS globals, as otherwise browser/deno runtimes can run
the module just fine in any case.
