### PR TITLE
chore: add some tests around freeze installs and ensure they permit new locks

### DIFF
--- a/test/api/install.test.js
+++ b/test/api/install.test.js
@@ -6,14 +6,16 @@ const generator = new Generator({
     imports: {
         react: "https://ga.jspm.io/npm:react@17.0.1/dev.index.js",
     },
+    scopes: {
+      "https://ga.jspm.io/": {
+        "lit-html": "https://ga.jspm.io/npm:lit-html@2.6.0/lit-html.js",
+      }
+    },
   },
   mapUrl: import.meta.url,
   env: ["production", "browser"],
   freeze: true, // lock versions
 });
-
-await generator.install();
-const json = generator.getMap();
 
 // Install with too many arguments should throw:
 try {
@@ -23,8 +25,28 @@ try {
   /* expected to throw */
 }
 
-// Install with no arguments should install all pins:
+// Install with no arguments should install all top-level pins.
+await generator.install();
+let json = generator.getMap();
+
 assert.strictEqual(
   json.imports.react,
   "https://ga.jspm.io/npm:react@17.0.1/index.js"
+);
+
+// Installing a new dependency with freeze should not throw, but it should
+// never bump versions from the import map:
+await generator.install(["lit@2.6.1", "lit-html"]);
+json = generator.getMap();
+
+assert.strictEqual(
+  json.imports.lit,
+  "https://ga.jspm.io/npm:lit@2.6.1/index.js",
+);
+
+// Even though latest for lit-html is 2.6.1, it should remain locked due to
+// the freeze option being set:
+assert.strictEqual(
+  json.imports["lit-html"],
+  "https://ga.jspm.io/npm:lit-html@2.6.0/lit-html.js",
 );


### PR DESCRIPTION
See #226. Freeze actually already has the desired behaviour described there,
i.e. freeze will permit new locks to be added to the lockfile, but will never
bump any existing lock versions during an install, and will always use existing
locks for any install wherever possible. I've just added a test and some
comments on the `installTarget` function to make this clearer.
