### PR TITLE
chore: pin down semantics of freeze with a bunch of test cases

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -279,7 +279,7 @@ export interface GeneratorOptions {
    * When using a lockfile, do not modify any existing resolutions, and use
    * existing resolutions whenever possible for new locks.
    */
-  freeze?: boolean;
+  freeze?: boolean; // TODO: deprecate and move to install/link options
 
   /**
    * When using a lockfile, force update touched resolutions to latest.
@@ -287,7 +287,7 @@ export interface GeneratorOptions {
    * @deprecated Defaults to 'true' for installs and updates, set to 'false'
    * to enable old behaviour.
    */
-  latest?: boolean;
+  latest?: boolean; // TODO: deprecate and move to install/link options
 
   /**
    * Support tracing CommonJS dependencies locally. This is necessary if you

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -336,6 +336,11 @@ export class Installer {
       `installing ${pkgName} from ${parentUrl} in scope ${pkgScope}`
     );
     if (!this.installing) throwInternalError("Not installing");
+    if (opts.latest && opts.freeze) {
+      throw new JspmError(
+        "Cannot enable 'freeze' and 'latest' install options simultaneously."
+      );
+    }
 
     // Anything installed in the scope of the installer's base URL is treated
     // as top-level, and hits the primary locks. Anything else is treated as

--- a/test/api/freeze.test.js
+++ b/test/api/freeze.test.js
@@ -13,8 +13,8 @@ import assert from 'assert';
  * When freeze is combined with "resolutions", the custom resolutions always
  * always take precedence over any of the freeze behaviour.
  *
- * When freeze is combined with "latest", the latest flag takes precedence and
- * all locks are upgraded to the latest compatible versions.
+ * When freeze is combined with "latest", the installer throws, as their
+ * behaviour is incompatible.
  */
 
 async function checkScenario(scenario) {
@@ -27,7 +27,12 @@ async function checkScenario(scenario) {
   });
 
   // install dependencies:
-  await Promise.all(scenario.install.map(pkg => generator.install(pkg)));
+  try {
+    await Promise.all(scenario.install.map(pkg => generator.install(pkg)));
+  } catch(err) {
+    if (!scenario.expect) return; // expected to throw, all good
+    throw err;
+  }
   const map = generator.getMap();
 
   // fetch installed versions
@@ -140,11 +145,6 @@ await Promise.all([
       latest: true,
     },
     install: ["lit", "react"],
-    expect: {
-      "lit-html": "latest",
-      "react": "latest",
-      "lit": "latest",
-      "chalk": "4.1.0", // not touched by installs, so not bumped
-    },
+    expect: false, // throws
   },
 ].map(checkScenario));

--- a/test/api/freeze.test.js
+++ b/test/api/freeze.test.js
@@ -1,0 +1,150 @@
+import { Generator, lookup, parseUrlPkg } from "@jspm/generator";
+import assert from 'assert';
+
+/**
+ * This test pins down the semantics of the "freeze" option on the generator.
+ *
+ * When enabled, the entire input map is treated as a strict lockfile, meaning
+ * no existing versions of any dependency will be changed by the generator. If
+ * there's a secondary lock for "react", for instance, then even a primary
+ * install will use that lock rather than latest. Freeze allows new dependencies
+ * to be added, however, if they have no existing locks.
+ *
+ * When freeze is combined with "resolutions", the custom resolutions always
+ * always take precedence over any of the freeze behaviour.
+ *
+ * When freeze is combined with "latest", the latest flag takes precedence and
+ * all locks are upgraded to the latest compatible versions.
+ */
+
+async function checkScenario(scenario) {
+  const generator = new Generator({
+    freeze: true,
+    mapUrl: import.meta.url,
+    inputMap: scenario.map ?? {},
+
+    ...(scenario.opts ?? {}),
+  });
+
+  // install dependencies:
+  await Promise.all(scenario.install.map(pkg => generator.install(pkg)));
+  const map = generator.getMap();
+
+  // fetch installed versions
+  let mdls = [];
+  for (const url of Object.values(map.imports || {}))
+    mdls.push(await parseUrlPkg(url));
+  for (const scope of Object.keys(map.scopes || {}))
+    for (const url of Object.values(map.scopes[scope]))
+      mdls.push(await parseUrlPkg(url));
+  function getVersions(pkg) {
+    return mdls
+      .filter(mdl => mdl.pkg.name === pkg)
+      .map(mdl => mdl.pkg.version);
+  }
+
+  // check constraints
+  for (let [pkg, version] of Object.entries(scenario.expect ?? {})) {
+    if (version === "latest") version = (await lookup(pkg)).resolved.version;
+
+    assert(
+      getVersions(pkg).every(v => v === version),
+      `freeze scenario "${scenario.name}" expected ${pkg}@${version}, but got [ ${getVersions(pkg).join(", ")} ]`,
+    );
+  }
+}
+
+await Promise.all([
+  {
+    name: "no existing locks",
+    install: ["lit", "react"],
+    expect: {
+      lit: "latest",
+      react: "latest",
+    },
+  },
+
+  {
+    name: "existing primary locks",
+    map: {
+      imports: {
+        "lit-html": "https://ga.jspm.io/npm:lit-html@2.6.0/development/lit-html.js",
+        "react": "https://ga.jspm.io/npm:react@18.1.0/dev.index.js",
+      }
+    },
+    install: ["lit", "react"],
+    expect: {
+      "lit-html": "2.6.0", // primary lock is hit for a secondary install
+      "react": "18.1.0", // primary lock is hit for a primary install
+      "lit": "latest",
+    },
+  },
+
+  {
+    name: "existing secondary locks",
+    map: {
+      scopes: {
+        "https://ga.jspm.io/": {
+          "lit-html/is-server.js": "https://ga.jspm.io/npm:lit-html@2.6.0/development/is-server.js"
+        }
+      }
+    },
+    install: ["lit", "lit-html", "react"],
+    expect: {
+      "lit-html": "2.6.0", // secondary lock is hit for primary install
+      "react": "latest",
+      "lit": "latest",
+    },
+  },
+
+  {
+    name: "combined with resolutions",
+    map: {
+      imports: {
+        "react": "https://ga.jspm.io/npm:react@18.1.0/dev.index.js",
+      },
+      scopes: {
+        "https://ga.jspm.io/": {
+          "lit-html/is-server.js": "https://ga.jspm.io/npm:lit-html@2.6.0/development/is-server.js"
+        }
+      }
+    },
+    opts: {
+      resolutions: {
+        "react": "18.2.0",
+        "lit-html": "2.6.1",
+      },
+    },
+    install: ["lit", "react"],
+    expect: {
+      "lit-html": "2.6.1", // resolution takes precedence
+      "react": "18.2.0", // resolution takes precedence
+      "lit": "latest",
+    },
+  },
+
+  {
+    name: "combined with latest",
+    map: {
+      imports: {
+        "react": "https://ga.jspm.io/npm:react@18.1.0/dev.index.js",
+        "chalk": "https://ga.jspm.io/npm:chalk@4.1.0/source/index.js",
+      },
+      scopes: {
+        "https://ga.jspm.io/": {
+          "lit-html/is-server.js": "https://ga.jspm.io/npm:lit-html@2.6.0/development/is-server.js"
+        }
+      }
+    },
+    opts: {
+      latest: true,
+    },
+    install: ["lit", "react"],
+    expect: {
+      "lit-html": "latest",
+      "react": "latest",
+      "lit": "latest",
+      "chalk": "4.1.0", // not touched by installs, so not bumped
+    },
+  },
+].map(checkScenario));

--- a/test/api/freeze.test.js
+++ b/test/api/freeze.test.js
@@ -52,7 +52,7 @@ async function checkScenario(scenario) {
 
   // check constraints
   for (let [pkg, version] of Object.entries(scenario.expect ?? {})) {
-    if (version === "latest") version = (await lookup(pkg)).resolved.version;
+    if (version === "latest") version = (await lookup(`${pkg}@latest`)).resolved.version;
 
     assert(
       getVersions(pkg).every(v => v === version),

--- a/test/api/local/freeze/package.json
+++ b/test/api/local/freeze/package.json
@@ -1,0 +1,7 @@
+{
+  "type": "module",
+  "description": "Constraints for 'freeze.test.js'.",
+  "dependencies": {
+    "chalk": "^4.0.0"
+  }
+}

--- a/test/api/local/freeze/package.json
+++ b/test/api/local/freeze/package.json
@@ -2,6 +2,6 @@
   "type": "module",
   "description": "Constraints for 'freeze.test.js'.",
   "dependencies": {
-    "chalk": "^4.0.0"
+    "chalk": "latest"
   }
 }

--- a/test/test.html
+++ b/test/test.html
@@ -10,7 +10,7 @@
   "scopes": {
     "../": {
       "#fetch": "../dist/fetch-native.js",
-      "@babel/core": "https://ga.jspm.io/npm:@babel/core@7.21.0/lib/index.js",
+      "@babel/core": "https://ga.jspm.io/npm:@babel/core@7.21.3/lib/index.js",
       "@babel/plugin-syntax-import-assertions": "https://ga.jspm.io/npm:@babel/plugin-syntax-import-assertions@7.20.0/lib/index.js",
       "@babel/preset-typescript": "https://ga.jspm.io/npm:@babel/preset-typescript@7.21.0/lib/index.js",
       "@jspm/import-map": "https://ga.jspm.io/npm:@jspm/import-map@1.0.7/dist/map.js",
@@ -23,16 +23,16 @@
       "url": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/url.js"
     },
     "https://ga.jspm.io/": {
-      "#lib/config/files/index.js": "https://ga.jspm.io/npm:@babel/core@7.21.0/lib/config/files/index-browser.js",
-      "#lib/config/resolve-targets.js": "https://ga.jspm.io/npm:@babel/core@7.21.0/lib/config/resolve-targets-browser.js",
-      "#lib/transform-file.js": "https://ga.jspm.io/npm:@babel/core@7.21.0/lib/transform-file-browser.js",
+      "#lib/config/files/index.js": "https://ga.jspm.io/npm:@babel/core@7.21.3/lib/config/files/index-browser.js",
+      "#lib/config/resolve-targets.js": "https://ga.jspm.io/npm:@babel/core@7.21.3/lib/config/resolve-targets-browser.js",
+      "#lib/transform-file.js": "https://ga.jspm.io/npm:@babel/core@7.21.3/lib/transform-file-browser.js",
       "#node.js": "https://ga.jspm.io/npm:browserslist@4.21.5/browser.js",
       "@ampproject/remapping": "https://ga.jspm.io/npm:@ampproject/remapping@2.2.0/dist/remapping.mjs",
       "@babel/code-frame": "https://ga.jspm.io/npm:@babel/code-frame@7.18.6/lib/index.js",
       "@babel/compat-data/native-modules": "https://ga.jspm.io/npm:@babel/compat-data@7.21.0/native-modules.js",
       "@babel/compat-data/plugins": "https://ga.jspm.io/npm:@babel/compat-data@7.21.0/plugins.js",
-      "@babel/core": "https://ga.jspm.io/npm:@babel/core@7.21.0/lib/index.js",
-      "@babel/generator": "https://ga.jspm.io/npm:@babel/generator@7.21.1/lib/index.js",
+      "@babel/core": "https://ga.jspm.io/npm:@babel/core@7.21.3/lib/index.js",
+      "@babel/generator": "https://ga.jspm.io/npm:@babel/generator@7.21.3/lib/index.js",
       "@babel/helper-annotate-as-pure": "https://ga.jspm.io/npm:@babel/helper-annotate-as-pure@7.18.6/lib/index.js",
       "@babel/helper-compilation-targets": "https://ga.jspm.io/npm:@babel/helper-compilation-targets@7.20.7/lib/index.js",
       "@babel/helper-create-class-features-plugin": "https://ga.jspm.io/npm:@babel/helper-create-class-features-plugin@7.21.0/lib/index.js",
@@ -53,12 +53,12 @@
       "@babel/helper-validator-option": "https://ga.jspm.io/npm:@babel/helper-validator-option@7.21.0/lib/index.js",
       "@babel/helpers": "https://ga.jspm.io/npm:@babel/helpers@7.21.0/lib/index.js",
       "@babel/highlight": "https://ga.jspm.io/npm:@babel/highlight@7.18.6/lib/index.js",
-      "@babel/parser": "https://ga.jspm.io/npm:@babel/parser@7.21.2/lib/index.js",
+      "@babel/parser": "https://ga.jspm.io/npm:@babel/parser@7.21.3/lib/index.js",
       "@babel/plugin-syntax-typescript": "https://ga.jspm.io/npm:@babel/plugin-syntax-typescript@7.20.0/lib/index.js",
-      "@babel/plugin-transform-typescript": "https://ga.jspm.io/npm:@babel/plugin-transform-typescript@7.21.0/lib/index.js",
+      "@babel/plugin-transform-typescript": "https://ga.jspm.io/npm:@babel/plugin-transform-typescript@7.21.3/lib/index.js",
       "@babel/template": "https://ga.jspm.io/npm:@babel/template@7.20.7/lib/index.js",
-      "@babel/traverse": "https://ga.jspm.io/npm:@babel/traverse@7.21.2/lib/index.js",
-      "@babel/types": "https://ga.jspm.io/npm:@babel/types@7.21.2/lib/index.js",
+      "@babel/traverse": "https://ga.jspm.io/npm:@babel/traverse@7.21.3/lib/index.js",
+      "@babel/types": "https://ga.jspm.io/npm:@babel/types@7.21.3/lib/index.js",
       "@jridgewell/gen-mapping": "https://ga.jspm.io/npm:@jridgewell/gen-mapping@0.1.1/dist/gen-mapping.umd.js",
       "@jridgewell/resolve-uri": "https://ga.jspm.io/npm:@jridgewell/resolve-uri@3.1.0/dist/resolve-uri.umd.js",
       "@jridgewell/set-array": "https://ga.jspm.io/npm:@jridgewell/set-array@1.1.2/dist/set-array.umd.js",
@@ -67,13 +67,13 @@
       "ansi-styles": "https://ga.jspm.io/npm:ansi-styles@3.2.1/index.js",
       "browserslist": "https://ga.jspm.io/npm:browserslist@4.21.5/index.js",
       "buffer": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/buffer.js",
-      "caniuse-lite/dist/unpacker/agents": "https://ga.jspm.io/npm:caniuse-lite@1.0.30001464/dist/unpacker/agents.js",
+      "caniuse-lite/dist/unpacker/agents": "https://ga.jspm.io/npm:caniuse-lite@1.0.30001468/dist/unpacker/agents.js",
       "chalk": "https://ga.jspm.io/npm:chalk@2.4.2/index.js",
       "color-convert": "https://ga.jspm.io/npm:color-convert@1.9.3/index.js",
       "color-name": "https://ga.jspm.io/npm:color-name@1.1.3/index.js",
       "convert-source-map": "https://ga.jspm.io/npm:convert-source-map@1.9.0/index.js",
       "debug": "https://ga.jspm.io/npm:debug@4.3.4/src/browser.js",
-      "electron-to-chromium/versions": "https://ga.jspm.io/npm:electron-to-chromium@1.4.328/versions.js",
+      "electron-to-chromium/versions": "https://ga.jspm.io/npm:electron-to-chromium@1.4.333/versions.js",
       "escape-string-regexp": "https://ga.jspm.io/npm:escape-string-regexp@1.0.5/index.js",
       "fs": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/fs.js",
       "gensync": "https://ga.jspm.io/npm:gensync@1.0.0-beta.2/index.js",
@@ -81,7 +81,6 @@
       "js-tokens": "https://ga.jspm.io/npm:js-tokens@4.0.0/index.js",
       "jsesc": "https://ga.jspm.io/npm:jsesc@2.5.2/jsesc.js",
       "lru-cache": "https://ga.jspm.io/npm:lru-cache@5.1.1/index.js",
-      "module": "https://ga.jspm.io/npm:@jspm/core@2.0.1/nodelibs/browser/module.js",
       "ms": "https://ga.jspm.io/npm:ms@2.1.2/index.js",
       "node-releases/data/processed/envs.json": "https://ga.jspm.io/npm:node-releases@2.0.10/data/processed/envs.json.js",
       "node-releases/data/release-schedule/release-schedule.json": "https://ga.jspm.io/npm:node-releases@2.0.10/data/release-schedule/release-schedule.json.js",
@@ -92,7 +91,7 @@
       "to-fast-properties": "https://ga.jspm.io/npm:to-fast-properties@2.0.0/index.js",
       "yallist": "https://ga.jspm.io/npm:yallist@3.1.1/yallist.js"
     },
-    "https://ga.jspm.io/npm:@babel/generator@7.21.1/": {
+    "https://ga.jspm.io/npm:@babel/generator@7.21.3/": {
       "@jridgewell/gen-mapping": "https://ga.jspm.io/npm:@jridgewell/gen-mapping@0.3.2/dist/gen-mapping.umd.js"
     }
   }


### PR DESCRIPTION
Added a comment in `test/api/freeze.test.js` specifying the intended semantics
of the freeze flag and a bunch of tests pinning down all the cases:

```js
/**
 * This test pins down the semantics of the "freeze" option on the generator.
 *
 * When enabled, the entire input map is treated as a strict lockfile, meaning
 * no existing versions of any dependency will be changed by the generator. If
 * there's a secondary lock for "react", for instance, then even a primary
 * install will use that lock rather than latest. Freeze allows new dependencies
 * to be added, however, if they have no existing locks.
 *
 * When freeze is combined with "resolutions", the custom resolutions always
 * always take precedence over any of the freeze behaviour.
 *
 * When freeze is combined with "latest", the latest flag takes precedence and
 * all locks are upgraded to the latest compatible versions.
 */
```
