### PR TITLE
fix: make sure esm.sh works with deno

### DIFF
--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -266,6 +266,7 @@ export class Resolver {
       case 403:
       case 404:
       case 406:
+      case 500:
         return false;
       default:
         throw new JspmError(

--- a/test/deno/esmsh.test.js
+++ b/test/deno/esmsh.test.js
@@ -1,0 +1,18 @@
+import { Generator } from "@jspm/generator";
+import { denoExec } from "#test/deno";
+
+const generator = new Generator({
+  mapUrl: import.meta.url,
+  env: ["production", "deno", "module"],
+  defaultProvider: "esm.sh",
+});
+
+// Install the NPM assert shim and use it to test itself!
+await generator.install('npm:assert@2.0.0');
+await denoExec(
+  generator.getMap(),
+  `
+  import { ok } from 'assert';
+  ok(1 === 1);
+  `
+);

--- a/test/providers/esmsh.test.js
+++ b/test/providers/esmsh.test.js
@@ -12,7 +12,7 @@ const json = generator.getMap();
 
 assert.strictEqual(
   json.imports.lit,
-  "https://esm.sh/*lit@2.0.0-rc.1/index.js"
+  "https://esm.sh/*lit@2.0.0-rc.1"
 );
 
 const scope = json.scopes["https://esm.sh/"];


### PR DESCRIPTION
Adds a test that checks `deno`/`esm.sh` support. Found a few bugs along the
way, such as the fact that `esm.sh` serves files based on their _export_
subpath rather than their actual subpath on the filesystem.
