### PR TITLE
fix: install with no args should not reinstall custom mappings

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1002,10 +1002,14 @@ export class Generator {
         "Install takes no arguments, a single install target, or a list of install targets."
       );
 
-    // If there are no arguments, install all top-level pins.
+    // If there are no arguments, then we reinstall all the top-level pins
+    // that were recognised by an installed provider (i.e. not custom mappings,
+    // which could correspond to arbitrary modules):
     if (!install) {
       await this.traceMap.processInputMap;
-      return this.install(this.traceMap.pins);
+      return this.install(
+        Object.keys(this.traceMap.installer.installs.primary)
+      );
     }
 
     // Split the case of multiple install targets:

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -1002,9 +1002,7 @@ export class Generator {
         "Install takes no arguments, a single install target, or a list of install targets."
       );
 
-    // If there are no arguments, then we reinstall all the top-level pins
-    // that were recognised by an installed provider (i.e. not custom mappings,
-    // which could correspond to arbitrary modules):
+    // If there are no arguments, then we reinstall all the top-level locks:
     if (!install) {
       await this.traceMap.processInputMap;
       return this.install(

--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -306,9 +306,15 @@ export class Resolver {
     const pkg = await resolveLatestTarget(latestTarget, layer, parentUrl);
     if (pkg) return pkg;
 
-    throw new JspmError(
-      `Unable to resolve package ${latestTarget.registry}:${latestTarget.name} in range "${latestTarget.range}" from parent ${parentUrl}`
-    );
+    if (provider === "nodemodules") {
+      throw new JspmError(
+        `${parentUrl}node_modules/${target.name} does not exist, try installing "${target.name}" with npm first via "npm install ${target.name}".`
+      );
+    } else {
+      throw new JspmError(
+        `Unable to resolve package ${latestTarget.registry}:${latestTarget.name} in range "${latestTarget.range}" from parent ${parentUrl}.`
+      );
+    }
   }
 
   async wasCommonJS(url: string): Promise<boolean> {


### PR DESCRIPTION
See https://github.com/jspm/jspm/issues/189. The logic for an install without
arguments in the generator is broken - we should be reinstalling top-level
_locks_, not top-level _pins_ (which can include custom mappings).
