### PR TITLE
fix: hook into deno.json for deno dependencies

### DIFF
--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -112,6 +112,14 @@ export class Installer {
     if (opts.defaultProvider)
       this.defaultProvider = parseProviderStr(opts.defaultProvider);
     this.providers = Object.assign({}, registryProviders);
+
+    // TODO: this is a hack, as we currently don't have proper support for
+    // providers owning particular registries. The proper way to do this would
+    // be to have each provider declare what registries it supports, and
+    // construct a providers mapping at init when we detect default provider:
+    if (opts.defaultProvider.includes("deno"))
+      this.providers["npm:"] = "jspm.io";
+
     if (opts.providers) Object.assign(this.providers, opts.providers);
   }
 

--- a/src/install/installer.ts
+++ b/src/install/installer.ts
@@ -118,7 +118,7 @@ export class Installer {
     // be to have each provider declare what registries it supports, and
     // construct a providers mapping at init when we detect default provider:
     if (opts.defaultProvider.includes("deno"))
-      this.providers["npm:"] = "jspm.io";
+      this.providers["npm:"] ??= "jspm.io";
 
     if (opts.providers) Object.assign(this.providers, opts.providers);
   }

--- a/src/providers/deno.ts
+++ b/src/providers/deno.ts
@@ -8,6 +8,7 @@ import { SemverRange } from "sver";
 // @ts-ignore
 import { fetch } from "#fetch";
 import { Install } from "../generator.js";
+import { IImportMap, ImportMap } from "@jspm/import-map";
 
 const cdnUrl = "https://deno.land/x/";
 const stdlibUrl = "https://deno.land/std";
@@ -148,6 +149,41 @@ export async function getPackageConfig(
       },
     };
   }
+
+  // If there's a package.json, return that:
+  const pkgJsonUrl = new URL("package.json", pkgUrl);
+  const pkgRes = await fetch(pkgJsonUrl.href, this.fetchOpts);
+  switch (pkgRes.status) {
+    case 200:
+    case 304:
+      return (await pkgRes.json()) as PackageConfig;
+  }
+
+  // If there's a deno.json, read off the top-level imports as deps:
+  const denoJsonUrl = new URL("deno.json", pkgUrl);
+  const denoRes = await fetch(denoJsonUrl.href, this.fetchOpts);
+  switch (denoRes.status) {
+    case 200:
+    case 304:
+      const json = await denoRes.json();
+
+      // If there's an "importMap" field, translate that:
+      if (json.importMap) {
+        const imRes = await fetch(
+          new URL(json.importMap, denoJsonUrl).href,
+          this.fetchOpts
+        );
+        switch (imRes.status) {
+          case 200:
+          case 304:
+            return translateMap(await imRes.json());
+        }
+      }
+
+      // Fallback to interpreting deno.json as an import map:
+      return translateMap(json);
+  }
+
   return null;
 }
 
@@ -232,4 +268,26 @@ export async function resolveLatestTarget(
   const { version } = (await parseUrlPkg(res.url)).pkg;
   if (registry === "deno") denoStdVersion = version;
   return { registry, name, version };
+}
+
+/**
+ * Translates a Deno import map into a package config with corresponding
+ * dependencies. This is a small hack to let us handle Deno dependencies that
+ * are managing their secondary dependencies with deno.json import maps.
+ *
+ * TODO:
+ * In theory we should be doing some kind of scoped merge of the dependency's
+ * import map, but for now we just translate the top-level imports:
+ */
+function translateMap(importMap: IImportMap): PackageConfig {
+  let res: PackageConfig = {
+    dependencies: {},
+  };
+
+  for (const [name, url] of Object.entries(importMap?.imports ?? {})) {
+    if (name.startsWith("$") || name.endsWith("/")) continue;
+    res.dependencies[name] = url;
+  }
+
+  return res;
 }

--- a/test/providers/deno.test.js
+++ b/test/providers/deno.test.js
@@ -43,37 +43,6 @@ const oakVersion = (await lookup("denoland:oak")).resolved.version;
   }
 }
 
-// {
-//   const generator = new Generator();
-
-//   await generator.link(new URL('./coremods/deno.js', import.meta.url).href);
-
-//   const json = generator.getMap();
-
-//   console.log(json);
-// }
-
-// {
-//   const generator = new Generator();
-
-//   await generator.install({ target: new URL('./coremods/', import.meta.url).href, subpath: './deno' });
-
-//   const json = generator.getMap();
-
-//   console.log(json);
-// }
-
-// {
-//   const generator = new Generator();
-
-//   try {
-//     await generator.link(new URL('./coremods/deno.notfound.js', import.meta.url).href);
-//   }
-//   catch (e) {
-//     console.log(e);
-//   }
-// }
-
 {
   const generator = new Generator({
     mapUrl: new URL("../../", import.meta.url),
@@ -222,16 +191,21 @@ const oakVersion = (await lookup("denoland:oak")).resolved.version;
     json.imports["testing/asserts"],
     `https://deno.land/std@0.148.0/testing/asserts.ts`
   );
+}
 
-  // await generator.update();
+{
+  const generator = new Generator({
+    defaultProvider: "deno",
+  });
 
-  // {
-  //   const json = generator.getMap();
+  await generator.install("denoland:fresh@1.1.5/runtime.ts");
+  const json = generator.getMap();
 
-  //   console.log(json);
-
-  //   assert.strictEqual(json.imports['fs'], `https://deno.land/std@${denoStdVersion}/fs/mod.ts`);
-  //   assert.strictEqual(json.imports['async/abortable.ts'], `https://deno.land/std@${denoStdVersion}/async/abortable.ts`);
-  //   assert.strictEqual(json.imports['testing/asserts'], `https://deno.land/std@${denoStdVersion}/testing/asserts.ts`);
-  // }
+  assert.strictEqual(
+    json.imports["fresh/runtime.ts"],
+    "https://deno.land/x/fresh@1.1.5/runtime.ts",
+  );
+  assert.ok(
+    json.scopes["https://deno.land/"]["preact"]?.includes("esm.sh"),
+  );
 }

--- a/test/providers/deno.test.js
+++ b/test/providers/deno.test.js
@@ -1,6 +1,23 @@
 import { Generator, lookup } from "@jspm/generator";
 import assert from "assert";
 
+{
+  const generator = new Generator({
+    defaultProvider: "deno",
+  });
+
+  await generator.install("denoland:fresh@1.1.5/runtime.ts");
+  const json = generator.getMap();
+
+  assert.strictEqual(
+    json.imports["fresh/runtime.ts"],
+    "https://deno.land/x/fresh@1.1.5/runtime.ts",
+  );
+  assert.ok(
+    json.scopes["https://deno.land/"]["preact"]
+  );
+}
+
 const denoStdVersion = (await lookup("deno:path")).resolved.version;
 const oakVersion = (await lookup("denoland:oak")).resolved.version;
 
@@ -190,22 +207,5 @@ const oakVersion = (await lookup("denoland:oak")).resolved.version;
   assert.strictEqual(
     json.imports["testing/asserts"],
     `https://deno.land/std@0.148.0/testing/asserts.ts`
-  );
-}
-
-{
-  const generator = new Generator({
-    defaultProvider: "deno",
-  });
-
-  await generator.install("denoland:fresh@1.1.5/runtime.ts");
-  const json = generator.getMap();
-
-  assert.strictEqual(
-    json.imports["fresh/runtime.ts"],
-    "https://deno.land/x/fresh@1.1.5/runtime.ts",
-  );
-  assert.ok(
-    json.scopes["https://deno.land/"]["preact"]?.includes("esm.sh"),
   );
 }


### PR DESCRIPTION
Fixes #289, or at least a first pass of a fix. This does the simplest thing for
now, which is to use the top-level imports for resolving a deno package's
secondary dependencies. This gets the `denoland:fresh/runtime.ts` example
working, for instance.
