### PR TITLE
fix: handle aliases and custom mappings more sanely in reinstalls

### DIFF
--- a/test/api/latest.test.js
+++ b/test/api/latest.test.js
@@ -1,6 +1,5 @@
 import { Generator, lookup, parseUrlPkg } from "@jspm/generator";
 import assert from "assert";
-import { fileURLToPath } from "url";
 
 /**
  * NPM has the following behaviour with respect to primary and secondary
@@ -44,74 +43,107 @@ const [latestReact, latestObjectAssign] = await (async () => {
   ];
 })();
 
-// primary not in package.json
-// shouldn't be removed or changed in any way
+// // primary not in package.json
+// // shouldn't be removed or changed in any way
+// {
+//   const g = generator(await getMapFor(['lit@^2.0.0']));
+//   await g.install();
+// 
+//   const map = g.getMap();
+//   assert.deepStrictEqual(
+//     (await parseUrlPkg(map.imports["lit"])).pkg,
+//     (await lookup("lit@^2.0.0")).resolved,
+//   );
+// }
+// 
+// // primary out-of-range
+// // should be replaced with an in-range latest
+// {
+//   const g = generator(await getMapFor(["react@16.14.0"]));
+//   await g.install();
+// 
+//   const map = g.getMap();
+//   assert.deepStrictEqual(
+//     (await parseUrlPkg(map.imports["react"])).pkg,
+//     latestReact,
+//   );
+// }
+// 
+// // primary in-range but not latest
+// // should be replaced with in-range latest
+// {
+//   const g = generator(await getMapFor(["react@16.13.0"]));
+//   await g.install();
+// 
+//   const map = g.getMap();
+//   assert.deepStrictEqual(
+//     (await parseUrlPkg(map.imports["react"])).pkg,
+//     latestReact,
+//   );
+// }
+// 
+// // primary in-range but not latest, installed under alias
+// // should be replaced with in-range latest
+// {
+//   const g = generator(await getMapFor([{
+//     alias: "alias",
+//     target: "react@16.13.0"
+//   }]));
+//   await g.install();
+// 
+//   const map = g.getMap();
+//   assert.deepStrictEqual(
+//     (await parseUrlPkg(map.imports["alias"])).pkg,
+//     latestReact,
+//   );
+// }
+// 
+// // secondary out-of-range
+// // should be replaced with in-range latest
+// {
+//   const g = generator(await getMapFor(["react@16.13.0"], {
+//     "object-assign": "~4.0.0",
+//   }));
+//   await g.install();
+// 
+//   const map = g.getMap();
+//   assert.deepStrictEqual(
+//     (await parseUrlPkg(map.scopes["https://ga.jspm.io/"]["object-assign"])).pkg,
+//     latestObjectAssign,
+//   );
+// }
+// 
+// // secondary in-range
+// // should use the existing lock
+// {
+//   const imap = await getMapFor(["react@16.13.0"], {
+//     "prop-types": "15.6.2",
+//   });
+//   const propTypes = 
+//     (await parseUrlPkg(imap.scopes["https://ga.jspm.io/"]["prop-types/checkPropTypes"])).pkg;
+//   const g = generator(imap);
+//   await g.install();
+// 
+//   const map = g.getMap();
+//   assert.deepStrictEqual(
+//     (await parseUrlPkg(map.scopes["https://ga.jspm.io/"]["prop-types/checkPropTypes"])).pkg,
+//     propTypes,
+//   );
+// }
+
+// primary custom mapping
+// should not be touched
 {
-  const g = generator(await getMapFor(['lit@^2.0.0']));
-  await g.install();
-
-  const map = g.getMap();
-  assert.deepStrictEqual(
-    (await parseUrlPkg(map.imports["lit"])).pkg,
-    (await lookup("lit@^2.0.0")).resolved,
-  );
-}
-
-// primary out-of-range
-// should be replaced with an in-range latest
-{
-  const g = generator(await getMapFor(["react@16.14.0"]));
-  await g.install();
-
-  const map = g.getMap();
-  assert.deepStrictEqual(
-    (await parseUrlPkg(map.imports["react"])).pkg,
-    latestReact,
-  );
-}
-
-// primary in-range but not latest
-// should be replaced with in-range latest
-{
-  const g = generator(await getMapFor(["react@16.13.0"]));
-  await g.install();
-
-  const map = g.getMap();
-  assert.deepStrictEqual(
-    (await parseUrlPkg(map.imports["react"])).pkg,
-    latestReact,
-  );
-}
-
-// secondary out-of-range
-// should be replaced with in-range latest
-{
-  const g = generator(await getMapFor(["react@16.13.0"], {
-    "object-assign": "~4.0.0",
-  }));
-  await g.install();
-
-  const map = g.getMap();
-  assert.deepStrictEqual(
-    (await parseUrlPkg(map.scopes["https://ga.jspm.io/"]["object-assign"])).pkg,
-    latestObjectAssign,
-  );
-}
-
-// secondary in-range
-// should use the existing lock
-{
-  const imap = await getMapFor(["react@16.13.0"], {
-    "prop-types": "15.6.2",
+  const g = generator({
+    imports: {
+      "react": "https://code.jquery.com/jquery-3.6.4.min.js",
+    },
   });
-  const propTypes = 
-    (await parseUrlPkg(imap.scopes["https://ga.jspm.io/"]["prop-types/checkPropTypes"])).pkg;
-  const g = generator(imap);
   await g.install();
 
   const map = g.getMap();
   assert.deepStrictEqual(
-    (await parseUrlPkg(map.scopes["https://ga.jspm.io/"]["prop-types/checkPropTypes"])).pkg,
-    propTypes,
+    map.imports.react,
+    "https://code.jquery.com/jquery-3.6.4.min.js",
   );
 }

--- a/test/api/latest.test.js
+++ b/test/api/latest.test.js
@@ -43,93 +43,93 @@ const [latestReact, latestObjectAssign] = await (async () => {
   ];
 })();
 
-// // primary not in package.json
-// // shouldn't be removed or changed in any way
-// {
-//   const g = generator(await getMapFor(['lit@^2.0.0']));
-//   await g.install();
-// 
-//   const map = g.getMap();
-//   assert.deepStrictEqual(
-//     (await parseUrlPkg(map.imports["lit"])).pkg,
-//     (await lookup("lit@^2.0.0")).resolved,
-//   );
-// }
-// 
-// // primary out-of-range
-// // should be replaced with an in-range latest
-// {
-//   const g = generator(await getMapFor(["react@16.14.0"]));
-//   await g.install();
-// 
-//   const map = g.getMap();
-//   assert.deepStrictEqual(
-//     (await parseUrlPkg(map.imports["react"])).pkg,
-//     latestReact,
-//   );
-// }
-// 
-// // primary in-range but not latest
-// // should be replaced with in-range latest
-// {
-//   const g = generator(await getMapFor(["react@16.13.0"]));
-//   await g.install();
-// 
-//   const map = g.getMap();
-//   assert.deepStrictEqual(
-//     (await parseUrlPkg(map.imports["react"])).pkg,
-//     latestReact,
-//   );
-// }
-// 
-// // primary in-range but not latest, installed under alias
-// // should be replaced with in-range latest
-// {
-//   const g = generator(await getMapFor([{
-//     alias: "alias",
-//     target: "react@16.13.0"
-//   }]));
-//   await g.install();
-// 
-//   const map = g.getMap();
-//   assert.deepStrictEqual(
-//     (await parseUrlPkg(map.imports["alias"])).pkg,
-//     latestReact,
-//   );
-// }
-// 
-// // secondary out-of-range
-// // should be replaced with in-range latest
-// {
-//   const g = generator(await getMapFor(["react@16.13.0"], {
-//     "object-assign": "~4.0.0",
-//   }));
-//   await g.install();
-// 
-//   const map = g.getMap();
-//   assert.deepStrictEqual(
-//     (await parseUrlPkg(map.scopes["https://ga.jspm.io/"]["object-assign"])).pkg,
-//     latestObjectAssign,
-//   );
-// }
-// 
-// // secondary in-range
-// // should use the existing lock
-// {
-//   const imap = await getMapFor(["react@16.13.0"], {
-//     "prop-types": "15.6.2",
-//   });
-//   const propTypes = 
-//     (await parseUrlPkg(imap.scopes["https://ga.jspm.io/"]["prop-types/checkPropTypes"])).pkg;
-//   const g = generator(imap);
-//   await g.install();
-// 
-//   const map = g.getMap();
-//   assert.deepStrictEqual(
-//     (await parseUrlPkg(map.scopes["https://ga.jspm.io/"]["prop-types/checkPropTypes"])).pkg,
-//     propTypes,
-//   );
-// }
+// primary not in package.json
+// shouldn't be removed or changed in any way
+{
+  const g = generator(await getMapFor(['lit@^2.0.0']));
+  await g.install();
+
+  const map = g.getMap();
+  assert.deepStrictEqual(
+    (await parseUrlPkg(map.imports["lit"])).pkg,
+    (await lookup("lit@^2.0.0")).resolved,
+  );
+}
+
+// primary out-of-range
+// should be replaced with an in-range latest
+{
+  const g = generator(await getMapFor(["react@16.14.0"]));
+  await g.install();
+
+  const map = g.getMap();
+  assert.deepStrictEqual(
+    (await parseUrlPkg(map.imports["react"])).pkg,
+    latestReact,
+  );
+}
+
+// primary in-range but not latest
+// should be replaced with in-range latest
+{
+  const g = generator(await getMapFor(["react@16.13.0"]));
+  await g.install();
+
+  const map = g.getMap();
+  assert.deepStrictEqual(
+    (await parseUrlPkg(map.imports["react"])).pkg,
+    latestReact,
+  );
+}
+
+// primary in-range but not latest, installed under alias
+// should be replaced with in-range latest
+{
+  const g = generator(await getMapFor([{
+    alias: "alias",
+    target: "react@16.13.0"
+  }]));
+  await g.install();
+
+  const map = g.getMap();
+  assert.deepStrictEqual(
+    (await parseUrlPkg(map.imports["alias"])).pkg,
+    latestReact,
+  );
+}
+
+// secondary out-of-range
+// should be replaced with in-range latest
+{
+  const g = generator(await getMapFor(["react@16.13.0"], {
+    "object-assign": "~4.0.0",
+  }));
+  await g.install();
+
+  const map = g.getMap();
+  assert.deepStrictEqual(
+    (await parseUrlPkg(map.scopes["https://ga.jspm.io/"]["object-assign"])).pkg,
+    latestObjectAssign,
+  );
+}
+
+// secondary in-range
+// should use the existing lock
+{
+  const imap = await getMapFor(["react@16.13.0"], {
+    "prop-types": "15.6.2",
+  });
+  const propTypes = 
+    (await parseUrlPkg(imap.scopes["https://ga.jspm.io/"]["prop-types/checkPropTypes"])).pkg;
+  const g = generator(imap);
+  await g.install();
+
+  const map = g.getMap();
+  assert.deepStrictEqual(
+    (await parseUrlPkg(map.scopes["https://ga.jspm.io/"]["prop-types/checkPropTypes"])).pkg,
+    propTypes,
+  );
+}
 
 // primary custom mapping
 // should not be touched

--- a/test/api/urls.test.js
+++ b/test/api/urls.test.js
@@ -1,6 +1,8 @@
 import { Generator } from "@jspm/generator";
 import assert from "assert";
 
+// TODO: enable these one we support arbitrary URL installation
+
 // Should be able to install a package scope URL directly, and it should
 // resolve to the default export in the scope's package.json:
 await (async (enabled=true) => {
@@ -47,7 +49,7 @@ await (async (enabled=true) => {
     map?.imports?.lit,
     "https://unpkg.com/lit@2.0.0/index.js",
   );
-})();
+})(false);
 
 // TODO
 // Should be able to install a module URL directly, even if that module URL is

--- a/test/api/urls.test.js
+++ b/test/api/urls.test.js
@@ -1,0 +1,55 @@
+import { Generator } from "@jspm/generator";
+import assert from "assert";
+
+// Should be able to install a package scope URL directly, and it should
+// resolve to the default export in the scope's package.json:
+await (async (enabled=true) => {
+  if (!enabled) return;
+
+  const gen = new Generator();
+  await gen.install("https://unpkg.com/lit@2.0.0/");
+  const map = gen.getMap();
+
+  assert.ok(map);
+  assert.strictEqual(
+    map?.imports?.lit,
+    "https://unpkg.com/lit@2.0.0/index.js",
+  );
+})(false);
+
+// Should be able to install a particular exports subpath from a package scope
+// URL directly using the pipe ("|") separator
+await (async (enabled=true) => {
+  if (!enabled) return;
+
+  const gen = new Generator();
+  await gen.install("https://unpkg.com/react@18.0.0|jsx-runtime");
+  const map = gen.getMap();
+
+  assert.ok(map);
+  assert.strictEqual(
+    map?.imports['react/jsx-runtime'],
+    "https://unpkg.com/react@18.0.0/jsx-runtime.js",
+  );
+})(false);
+
+// Should be able to install a module URL directly, if that module URL is
+// present as an export in the scope's package.json:
+await (async (enabled=true) => {
+  if (!enabled) return;
+
+  const gen = new Generator();
+  await gen.install("https://unpkg.com/lit@2.0.0/index.js");
+  const map = gen.getMap();
+
+  assert.ok(map);
+  assert.strictEqual(
+    map?.imports?.lit,
+    "https://unpkg.com/lit@2.0.0/index.js",
+  );
+})();
+
+// TODO
+// Should be able to install a module URL directly, even if that module URL is
+// _not_ present as an export in the scope's package.json. This is a case of
+// "let people who know what they're doing actually do it":


### PR DESCRIPTION
See #291. Plan is to hack arbitrary URL installation into the CLI for now, but
this custom mapping/alias issue was causing _that_ to fail too.
