### PR TITLE
fix: don't throw on 500s from esm.sh

### DIFF
--- a/src/providers/esmsh.ts
+++ b/src/providers/esmsh.ts
@@ -39,6 +39,7 @@ export async function getPackageConfig(
     case 403:
     case 404:
     case 406:
+    case 500:
       this.pcfgs[pkgUrl] = null;
       return;
     default:

--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -211,6 +211,7 @@ export class Resolver {
           case 403:
           case 404:
           case 406:
+          case 500:
             this.pcfgs[pkgUrl] = null;
             return;
           default:


### PR DESCRIPTION
Seems like `esm.sh` returns 500s occasionally for what are actually `404`s,
when we're searching for package boundaries.
