### PR TITLE
(chore): Add dependabot to check updates for generator and es-module-lexer

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+updates:
+  - package-ecosystem: npm
+    directory: /
+    schedule:
+      interval: daily
+    allow:
+      - dependency-name: '@jspm/import-map'
+      - dependency-name: 'es-module-lexer'


### PR DESCRIPTION
Although  `dependabot` doesn't immediately trigger the update when `@jspm/import-map` is updated. This is good to have when a `minor` versions are missed. And when there is a change for `es-module-lexer` as well.