### PR TITLE
Update resolver.ts to prevent crashing when encountering WASM modules

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -320,7 +320,7 @@ export interface GeneratorOptions {
 }
 
 export interface ModuleAnalysis {
-  format: "commonjs" | "esm" | "system" | "json" | "typescript";
+  format: "commonjs" | "esm" | "system" | "json" | "typescript" | "wasm";
   staticDeps: string[];
   dynamicDeps: string[];
   cjsLazyDeps: string[] | null;

--- a/src/trace/analysis.ts
+++ b/src/trace/analysis.ts
@@ -2,7 +2,7 @@ export interface Analysis {
   deps: string[];
   dynamicDeps: string[];
   cjsLazyDeps: string[] | null;
-  format: "esm" | "commonjs" | "system" | "json" | "typescript";
+  format: "esm" | "commonjs" | "system" | "json" | "typescript" | "wasm";
   size: number;
 
   // for commonjs format, true iff the module uses a CJS-only global

--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -853,6 +853,16 @@ export class Resolver {
       )
         return await createTsAnalysis(source, resolvedUrl);
 
+      if (resolvedUrl.endsWith(".wasm")) {
+          return {
+              deps: [],
+              dynamicDeps: [],
+              cjsLazyDeps: null,
+              size: source.length,
+              format: "wasm"
+          }
+      }
+
       if (resolvedUrl.endsWith(".json")) {
         try {
           JSON.parse(source);

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -85,7 +85,7 @@ interface TraceEntry {
   // For cjs modules, the list of hoisted deps
   // this is needed for proper cycle handling
   cjsLazyDeps: string[];
-  format: "esm" | "commonjs" | "system" | "json" | "typescript";
+  format: "esm" | "commonjs" | "system" | "json" | "typescript" | "wasm";
 }
 
 interface VisitOpts {


### PR DESCRIPTION
Not sure if this is a great approach but it appears to work in my narrow use-case whereas before I got a crash that looked thus:

```
file:///Users/pvh/Dev/blutack/node_modules/@jspm/generator/dist/generator-49949c79.js:1800
                throw new JspmError(`${errStack}\n\nError parsing ${resolvedUrl}:${pos}`);
                      ^
JspmError: 
  asm����>`````~`|```~```~`````````     `       `
> `
   ```` ~~~`~`~~`|`~`~`|`|`||`~`~`~`~~`~|`}`|`|`|`~`~`~`~`~`~`~~`~~~~`}`|`|`~`~`~~~`|`||����V./automerge_wasm_bg.js__wbindgen_object_drop_ref./automerge_wasm_bg.js__wbindgen_error_new./automerge_wasm_bg.js__wbindgen_string_get./automerge_wasm_bg.js__wbg_new_abda76e883ba8a5f./automerge_wasm_bg.js__wbg_stack_658279fe44541cf6./automerge_wasm_bg.js__wbg_error_f851667af71bcfc6./automerge_wasm_bg.js__wbindgen_is_object./automerge_wasm_bg.js__wbindgen_jsval_loose_eq./automerge_wasm_bg.js__wbg_String_91fba7ded13ba54c./automerge_wasm_bg.js__wbindgen_bigint_from_i649./automerge_wasm_bg.js__wbindgen_bigint_from_u649./automerge_wasm_bg.js__wbg_set_20cbc34131e76824    ./automerge_wasm_bg.js&__wbg_getRandomValues_37fa2ca9e4e07fab./automerge_wasm_bg.js%__wbg_randomFillSync_dc1e9a60c158336d./automerge_wasm_bg.js__wbg_crypto_c48a774b022d20ac./automerge_wasm_bg.js__wbg_process_298734cf255a885d./automerge_wasm_bg.js__wbg_versions_e2e78e134e3e5d01./automerge_wasm_bg.js__wbg_log_1d3ae0273d8f4f8a./automerge_wasm_bg.js__wbg_log_576ca876af0d4a77./automerge_wasm_bg.js__wbg_get_44be0491f933a435./automerge_wasm_bg.js__wbg_length_fff51ee6522a1a18./automerge_wasm_bg.js__wbg_new_898a68150f225f2e./automerge_wasm_bg.js __wbg_newnoargs_581967eacc0e2604./automerge_wasm_bg.js__wbg_get_97b561fb56f034b5./automerge_wasm_bg.js__wbg_new_b51585de1b234aff./automerge_wasm_bg.js__wbg_length_b3de0c6587c18245./automerge_wasm_bg.js__wbg_set_502d29070ea18557    ./automerge_wasm_bg.js__wbg_new_d258248ed531ff54./automerge_wasm_bg.js__wbg_new_cd59bfc8881f487b./automerge_wasm_bg.js(__wbg_instanceof_Object_3daa8298c86298be./automerge_wasm_bg.js__wbg_assign_999478a110912e87./automerge_wasm_bg.js%__wbg_defineProperty_2db1bcb00cd9da96

Error parsing https://ga.jspm.io/npm:@automerge/automerge-wasm@0.2.6/bundler/automerge_wasm_bg.wasm:2:3155
    at Resolver.analyze (file:///Users/pvh/Dev/blutack/node_modules/@jspm/generator/dist/generator-49949c79.js:1800:23)
    at async file:///Users/pvh/Dev/blutack/node_modules/@jspm/generator/dist/generator-49949c79.js:2953:85
    at async TraceMap.getTraceEntry (file:///Users/pvh/Dev/blutack/node_modules/@jspm/generator/dist/generator-49949c79.js:2965:9)
    at async TraceMap.visit (file:///Users/pvh/Dev/blutack/node_modules/@jspm/generator/dist/generator-49949c79.js:2710:23)
    at async file:///Users/pvh/Dev/blutack/node_modules/@jspm/generator/dist/generator-49949c79.js:2743:13
    at async Promise.all (index 0)
    at async TraceMap.visit (file:///Users/pvh/Dev/blutack/node_modules/@jspm/generator/dist/generator-49949c79.js:2738:9)
    at async file:///Users/pvh/Dev/blutack/node_modules/@jspm/generator/dist/generator-49949c79.js:2743:13
    at async Promise.all (index 0)
    at async TraceMap.visit (file:///Users/pvh/Dev/blutack/node_modules/@jspm/generator/dist/generator-49949c79.js:2738:9) {
  jspmError: true,
  code: undefined
}
```

As far as I can tell WASM modules can't have any dependencies so I think this is correct? Let me know if I can provide any more information.