### PR TITLE
fix: fs/promises builtin linkage case

### DIFF
--- a/src/providers/node.ts
+++ b/src/providers/node.ts
@@ -89,7 +89,7 @@ export function resolveBuiltin(
   specifier: string,
   env: string[]
 ): string | Install | undefined {
-  const builtin = specifier.startsWith("node:")
+  let builtin = specifier.startsWith("node:")
     ? specifier.slice(5)
     : nodeBuiltinSet.has(specifier)
     ? specifier
@@ -103,6 +103,10 @@ export function resolveBuiltin(
   if (env.includes("deno") || env.includes("node")) {
     return `node:${builtin}`;
   }
+
+  // Strip the subpath for subpathed builtins
+  if (builtin.includes('/'))
+    builtin = builtin.split('/')[0];
 
   return {
     target: {

--- a/test/api/node.test.js
+++ b/test/api/node.test.js
@@ -2,6 +2,19 @@ import { Generator, lookup } from "@jspm/generator";
 import assert from "assert";
 
 {
+  const generator = new Generator();
+
+  await generator.link('fs/promises');
+
+  const json = generator.getMap();
+
+  assert.strictEqual(
+    json.imports["fs/promises"].split('/').slice(-4).join('/'),
+    `nodelibs/browser/fs/promises.js`
+  );
+}
+
+{
   const generator = new Generator({
     env: ["production", "browser"],
   });


### PR DESCRIPTION
This fixes a bug where `fs/promises` wouldn't link correctly and throw the generation, due to it not being properly structured in the internal package resolution structure.