### PR TITLE
fix: esmsh provider es module shims url

### DIFF
--- a/src/common/wrapper.ts
+++ b/src/common/wrapper.ts
@@ -1,0 +1,14 @@
+import { fetch } from '#fetch';
+import { parse, init } from 'es-module-lexer';
+
+export async function getMaybeWrapperUrl (moduleUrl, fetchOpts) {
+  await init;
+  const source = await (await fetch(moduleUrl, fetchOpts)).text();
+  const [imports,, facade] = parse(source);
+  if (facade && imports.length) {
+    try {
+      return new URL(imports[0].n, moduleUrl).href;
+    } catch {}
+  }
+  return moduleUrl;
+}

--- a/src/common/wrapper.ts
+++ b/src/common/wrapper.ts
@@ -1,3 +1,4 @@
+//@ts-ignore
 import { fetch } from '#fetch';
 import { parse, init } from 'es-module-lexer';
 

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -43,6 +43,7 @@ import { LockResolutions } from "./install/lock.js";
 import { getDefaultProviderStrings, type Provider } from "./providers/index.js";
 import * as nodemodules from "./providers/nodemodules.js";
 import { Resolver } from "./trace/resolver.js";
+import { getMaybeWrapperUrl } from './common/wrapper.js';
 
 // Utility exports for users:
 export { analyzeHtml };
@@ -729,6 +730,10 @@ export class Generator {
           esmsPkg,
           this.traceMap.installer.defaultProvider
         )) + "dist/es-module-shims.js";
+
+      // detect esmsUrl as a wrapper URL
+      esmsUrl = await getMaybeWrapperUrl(esmsUrl, this.traceMap.resolver.fetchOpts);
+
       if (htmlUrl || rootUrl)
         esmsUrl = relativeUrl(
           new URL(esmsUrl),

--- a/test/html/esmsh.test.js
+++ b/test/html/esmsh.test.js
@@ -1,0 +1,25 @@
+import { Generator } from "@jspm/generator";
+import assert from "assert";
+import { SemverRange } from "sver";
+
+const generator = new Generator({
+  mapUrl: new URL("./local/page.html", import.meta.url),
+  env: ["production", "browser"],
+  defaultProvider: 'esm.sh'
+});
+
+const esmsPkg = await generator.traceMap.resolver.resolveLatestTarget(
+  { name: "es-module-shims", registry: "npm", ranges: [new SemverRange("*")] },
+  generator.traceMap.installer.defaultProvider
+);
+let pins, html
+
+html = `
+<!doctype html>
+<script type="module">
+  import 'react';
+</script>
+`;
+pins = await generator.addMappings(html);
+
+assert((await generator.htmlInject(html, { pins })).includes('https://esm.sh/v'));


### PR DESCRIPTION
Resolves https://github.com/jspm/generator/issues/353 ensuring that the generated esm.sh URL for es-module-shims unwraps the wrapper.