### PR TITLE
add failing test for issue with openai and langchain

### DIFF
--- a/test/api/conflict.test.js
+++ b/test/api/conflict.test.js
@@ -1,0 +1,12 @@
+import { Generator } from "@jspm/generator";
+import assert from "assert";
+
+const generator = new Generator({
+  mapUrl: '.',
+  defaultProvider: "jspm.io",
+  env: ["production", "browser"],
+});
+await generator.install(["openai@latest", "langchain@latest/text_splitter"])
+const json = generator.getMap();
+console.log("json", json);
+assert.ok(json.imports["openai"]);


### PR DESCRIPTION
The generator crashes when installing `openai` along with `langchain/text_splitter`.