### PR TITLE
feat: package subpath extension searching for both cjs and non-exports resolution

### DIFF
--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -447,7 +447,10 @@ export class Resolver {
 
     // give some compatibility for packages without "exports" field
     if (!exportsResolution) {
-      if (!(await this.exists(url)) && await this.exists(url + ".js")) return url + ".js";
+      if (await this.exists(url)) void 0;
+      else if (await this.exists(url + ".js")) return url + ".js";
+      else if (await this.exists(url + ".json")) return url + ".json";
+      else if (await this.exists(url + ".node")) return url + ".node";
     }
 
     return url;

--- a/src/trace/tracemap.ts
+++ b/src/trace/tracemap.ts
@@ -422,11 +422,7 @@ export default class TraceMap {
         );
       const resolvedHref = resolvedUrl.href;
       let finalized = await this.resolver.realPath(
-        await this.resolver.finalizeResolve(
-          resolvedHref,
-          parentIsCjs,
-          parentPkgUrl
-        )
+        await this.resolver.finalizeResolve(resolvedHref, parentIsCjs, false, parentPkgUrl)
       );
 
       // handle URL mappings

--- a/test/resolve/dayjs.test.js
+++ b/test/resolve/dayjs.test.js
@@ -1,0 +1,10 @@
+import { Generator } from "@jspm/generator";
+import assert from "assert";
+
+const generator = new Generator({
+  defaultProvider: 'jsdelivr'
+});
+
+await generator.install("@cubejs-client/core@0.35.23");
+const json = generator.getMap();
+assert(Object.keys(json.imports).length === 1);


### PR DESCRIPTION
Currently we only do extension searching in package subpath resolutions when the package is a CommonJS package, per the Node.js resolution rules.

This resolves https://github.com/jspm/generator/issues/355 in also performing subpath extension searching for extensions in addition when the subpath resolution is not resolved through exports.