### PR TITLE
Support provider configuration, with JSPM cdnUrl configuration

### DIFF
--- a/src/generator.ts
+++ b/src/generator.ts
@@ -40,12 +40,11 @@ import { Replacer } from "./common/str.js";
 import { analyzeHtml } from "./html/analyze.js";
 import { InstallTarget, type InstallMode } from "./install/installer.js";
 import { LockResolutions } from "./install/lock.js";
-import { getDefaultProviderStrings, type Provider } from "./providers/index.js";
+import { configureProviders, getDefaultProviderStrings, type Provider } from "./providers/index.js";
 import * as nodemodules from "./providers/nodemodules.js";
 import { Resolver } from "./trace/resolver.js";
 import { getMaybeWrapperUrl } from "./common/wrapper.js";
 import { setRetryCount } from "./common/fetch-common.js";
-import { getProvider } from "./providers/index.js";
 
 // Utility exports for users:
 export { analyzeHtml };
@@ -545,13 +544,7 @@ export class Generator {
     if (typeof fetchRetries === 'number')
       setRetryCount(fetchRetries);
 
-    // Apply provider configurations
-    for (const [providerName, config] of Object.entries(providerConfig)) {
-      const provider = getProvider(providerName, resolver.providers);
-      if (provider && provider.configure) {
-        provider.configure(config);
-      }
-    }
+    configureProviders(providerConfig, resolver.providers);
   }
 
   /**

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -70,6 +70,15 @@ export function getProvider(name: string, providers: Record<string, Provider>) {
   throw new JspmError(`No provider named "${name}" has been defined.`);
 }
 
+// Apply provider configurations
+export function configureProviders(providerConfig: Record<string, any>, providers: Record<string, Provider>) {
+  for (const [providerName, provider] of Object.entries(providers)) {
+    if (provider.configure) {
+      provider.configure(providerConfig[providerName] || {});
+    }
+  }
+}
+
 export function getDefaultProviderStrings() {
   let res = [];
   for (const [name, provider] of Object.entries(defaultProviders)) {

--- a/src/providers/index.ts
+++ b/src/providers/index.ts
@@ -50,6 +50,8 @@ export interface Provider {
   ): Promise<PackageConfig | null>;
 
   supportedLayers?: string[];
+
+  configure?(config: any): void;
 }
 
 export const defaultProviders: Record<string, Provider> = {

--- a/src/providers/jspm.ts
+++ b/src/providers/jspm.ts
@@ -9,12 +9,12 @@ import { SemverRange } from "sver";
 // @ts-ignore
 import { fetch } from "#fetch";
 
-const cdnUrl = "https://ga.jspm.io/";
+let cdnUrl = "https://ga.jspm.io/";
 const systemCdnUrl = "https://ga.system.jspm.io/";
 const apiUrl = "https://api.jspm.io/";
 
-const BUILD_POLL_TIME = 5 * 60 * 1000;
-const BUILD_POLL_INTERVAL = 5 * 1000;
+const BUILD_POLL_INTERVAL = 1000;
+const BUILD_POLL_TIME = 120000;
 
 export const supportedLayers = ["default", "system"];
 
@@ -23,6 +23,12 @@ export async function pkgToUrl(
   layer: string
 ): Promise<`${string}/`> {
   return `${layer === "system" ? systemCdnUrl : cdnUrl}${pkgToStr(pkg)}/`;
+}
+
+export function configure(config: any) {
+  if (config.cdnUrl) {
+    cdnUrl = config.cdnUrl;
+  }
 }
 
 const exactPkgRegEx =

--- a/src/providers/jspm.ts
+++ b/src/providers/jspm.ts
@@ -13,8 +13,8 @@ let cdnUrl = "https://ga.jspm.io/";
 const systemCdnUrl = "https://ga.system.jspm.io/";
 const apiUrl = "https://api.jspm.io/";
 
-const BUILD_POLL_INTERVAL = 1000;
-const BUILD_POLL_TIME = 120000;
+const BUILD_POLL_TIME = 5 * 60 * 1000;
+const BUILD_POLL_INTERVAL = 5 * 1000;
 
 export const supportedLayers = ["default", "system"];
 

--- a/src/providers/jspm.ts
+++ b/src/providers/jspm.ts
@@ -26,9 +26,7 @@ export async function pkgToUrl(
 }
 
 export function configure(config: any) {
-  if (config.cdnUrl) {
-    cdnUrl = config.cdnUrl;
-  }
+  cdnUrl = config.cdnUrl || "https://ga.jspm.io/";
 }
 
 const exactPkgRegEx =

--- a/test/providers/config.test.js
+++ b/test/providers/config.test.js
@@ -1,7 +1,8 @@
 import { Generator } from "@jspm/generator";
 import assert from "assert";
 
-const name = Buffer.from("7169746b616f2e636f6d", "hex").toString();
+// this private origin shouldn't really be shared publicly
+const name = [111, 97, 107, 116, 105, 113].map(x => String.fromCharCode(x)).reverse().join('');
 
 // Test with custom CDN URL
 {
@@ -10,7 +11,7 @@ const name = Buffer.from("7169746b616f2e636f6d", "hex").toString();
     defaultProvider: "jspm.io",
     providerConfig: {
       "jspm.io": {
-        cdnUrl: `https://${name}/`
+        cdnUrl: `https://${name}.com/`
       }
     }
   });
@@ -20,6 +21,6 @@ const name = Buffer.from("7169746b616f2e636f6d", "hex").toString();
 
   assert.strictEqual(
     json.imports.react,
-    `https://${name}/npm:react@17.0.1/dev.index.js`
+    `https://${name}.com/npm:react@17.0.1/dev.index.js`
   );
 }

--- a/test/providers/config.test.js
+++ b/test/providers/config.test.js
@@ -1,0 +1,25 @@
+import { Generator } from "@jspm/generator";
+import assert from "assert";
+
+const name = Buffer.from("7169746b616f2e636f6d", "hex").toString();
+
+// Test with custom CDN URL
+{
+  const generator = new Generator({
+    mapUrl: import.meta.url,
+    defaultProvider: "jspm.io",
+    providerConfig: {
+      "jspm.io": {
+        cdnUrl: `https://${name}/`
+      }
+    }
+  });
+
+  await generator.install("react@17.0.1");
+  const json = generator.getMap();
+
+  assert.strictEqual(
+    json.imports.react,
+    `https://${name}/npm:react@17.0.1/dev.index.js`
+  );
+}


### PR DESCRIPTION
Adds a new `providerConfig` option to the generator which allows configuring providers through a `configure` provider hook.

For the JSPM provider, a `cdnUrl` configuration is added to customize the CDN URL.