### PR TITLE
fix: provider lookups to use standard npm packument

### DIFF
--- a/src/providers/jsdelivr.ts
+++ b/src/providers/jsdelivr.ts
@@ -1,4 +1,10 @@
-import { ExactPackage } from "../install/package.js";
+import { JspmError } from "../common/err.js";
+import { importedFrom } from "../common/url.js";
+import { ExactPackage, LatestPackageTarget } from "../install/package.js";
+import { Resolver } from "../trace/resolver.js";
+import { fetchVersions } from "./jspm.js";
+// @ts-ignore
+import { SemverRange } from "sver";
 
 const cdnUrl = "https://cdn.jsdelivr.net/";
 
@@ -16,5 +22,22 @@ export function parseUrlPkg(url: string) {
   return { registry, name, version };
 }
 
-// Use JSPM version resolver for now
-export { resolveLatestTarget } from "./jspm.js";
+export async function resolveLatestTarget(
+  this: Resolver,
+  target: LatestPackageTarget,
+  layer: string,
+  parentUrl: string
+): Promise<ExactPackage | null> {
+  const { registry, name, range, unstable } = target;
+  const versions = await fetchVersions(name);
+  const semverRange = new SemverRange(String(range) || "*", unstable);
+  const version = semverRange.bestMatch(versions, unstable);
+  if (version) {
+    return { registry, name, version: version.toString() };
+  }
+  throw new JspmError(
+    `Unable to resolve ${registry}:${name}@${range} to a valid version${importedFrom(
+      parentUrl
+    )}`
+  );
+}

--- a/src/providers/jspm.ts
+++ b/src/providers/jspm.ts
@@ -305,7 +305,7 @@ async function lookupRange(
         `Unable to resolve ${registry}:${name}@${range} to a valid version${importedFrom(
           parentUrl
         )}`
-      ); 
+      );
     }
   })();
   lookupCache.set(url, lookupPromise);
@@ -314,7 +314,7 @@ async function lookupRange(
 
 const versionsCacheMap = new Map<string, string[]>();
 
-async function fetchVersions(name: string): Promise<string[]> {
+export async function fetchVersions(name: string): Promise<string[]> {
   if (versionsCacheMap.has(name)) {
     return versionsCacheMap.get(name);
   }

--- a/src/providers/skypack.ts
+++ b/src/providers/skypack.ts
@@ -1,4 +1,10 @@
-import { ExactPackage } from "../install/package.js";
+import { JspmError } from "../common/err.js";
+import { importedFrom } from "../common/url.js";
+import { ExactPackage, LatestPackageTarget } from "../install/package.js";
+import { Resolver } from "../trace/resolver.js";
+import { fetchVersions } from "./jspm.js";
+// @ts-ignore
+import { SemverRange } from "sver";
 
 const cdnUrl = "https://cdn.skypack.dev/";
 
@@ -15,5 +21,22 @@ export function parseUrlPkg(url: string) {
   return { registry: "npm", name, version };
 }
 
-// Use JSPM version resolver for now:
-export { resolveLatestTarget } from "./jspm.js";
+export async function resolveLatestTarget(
+  this: Resolver,
+  target: LatestPackageTarget,
+  layer: string,
+  parentUrl: string
+): Promise<ExactPackage | null> {
+  const { registry, name, range, unstable } = target;
+  const versions = await fetchVersions(name);
+  const semverRange = new SemverRange(String(range) || "*", unstable);
+  const version = semverRange.bestMatch(versions, unstable);
+  if (version) {
+    return { registry, name, version: version.toString() };
+  }
+  throw new JspmError(
+    `Unable to resolve ${registry}:${name}@${range} to a valid version${importedFrom(
+      parentUrl
+    )}`
+  );
+}

--- a/src/providers/unpkg.ts
+++ b/src/providers/unpkg.ts
@@ -1,4 +1,10 @@
-import { ExactPackage } from "../install/package.js";
+import { JspmError } from "../common/err.js";
+import { importedFrom } from "../common/url.js";
+import { ExactPackage, LatestPackageTarget } from "../install/package.js";
+import { Resolver } from "../trace/resolver.js";
+import { fetchVersions } from "./jspm.js";
+// @ts-ignore
+import { SemverRange } from "sver";
 
 const cdnUrl = "https://unpkg.com/";
 
@@ -16,5 +22,22 @@ export function parseUrlPkg(url: string) {
   }
 }
 
-// Use JSPM version resolver for now
-export { resolveLatestTarget } from "./jspm.js";
+export async function resolveLatestTarget(
+  this: Resolver,
+  target: LatestPackageTarget,
+  layer: string,
+  parentUrl: string
+): Promise<ExactPackage | null> {
+  const { registry, name, range, unstable } = target;
+  const versions = await fetchVersions(name);
+  const semverRange = new SemverRange(String(range) || "*", unstable);
+  const version = semverRange.bestMatch(versions, unstable);
+  if (version) {
+    return { registry, name, version: version.toString() };
+  }
+  throw new JspmError(
+    `Unable to resolve ${registry}:${name}@${range} to a valid version${importedFrom(
+      parentUrl
+    )}`
+  );
+}


### PR DESCRIPTION
This resolves https://github.com/jspm/generator/issues/379 ensuring that we always use the direct npm packument-style version lookups for non-JSPM providers.