### PR TITLE
fix: clear version cache on each generator instantiation

### DIFF
--- a/src/providers/esmsh.ts
+++ b/src/providers/esmsh.ts
@@ -85,7 +85,7 @@ export async function resolveLatestTarget(
   parentUrl: string
 ): Promise<ExactPackage | null> {
   const { registry, name, range, unstable } = target;
-  const versions = await fetchVersions(name);
+  const versions = await fetchVersions.call(this, name);
   const semverRange = new SemverRange(String(range) || "*", unstable);
   const version = semverRange.bestMatch(versions, unstable);
   if (version) {

--- a/src/providers/jsdelivr.ts
+++ b/src/providers/jsdelivr.ts
@@ -29,7 +29,7 @@ export async function resolveLatestTarget(
   parentUrl: string
 ): Promise<ExactPackage | null> {
   const { registry, name, range, unstable } = target;
-  const versions = await fetchVersions(name);
+  const versions = await fetchVersions.call(this, name);
   const semverRange = new SemverRange(String(range) || "*", unstable);
   const version = semverRange.bestMatch(versions, unstable);
   if (version) {

--- a/src/providers/jspm.ts
+++ b/src/providers/jspm.ts
@@ -28,6 +28,8 @@ export async function pkgToUrl(
 export function configure(config: any) {
   if (config.cdnUrl)
     cdnUrl = config.cdnUrl;
+  lookupCache = new Map();
+  versionsCacheMap = new Map();
 }
 
 const exactPkgRegEx =
@@ -275,7 +277,7 @@ function pkgToLookupUrl(pkg: ExactPackage, edge = false) {
   }`;
 }
 
-const lookupCache = new Map();
+let lookupCache = new Map();
 
 async function lookupRange(
   this: Resolver,
@@ -312,7 +314,7 @@ async function lookupRange(
   return lookupPromise;
 }
 
-const versionsCacheMap = new Map<string, string[]>();
+let versionsCacheMap = new Map<string, string[]>();
 
 export async function fetchVersions(name: string): Promise<string[]> {
   if (versionsCacheMap.has(name)) {

--- a/src/providers/jspm.ts
+++ b/src/providers/jspm.ts
@@ -16,6 +16,22 @@ const apiUrl = "https://api.jspm.io/";
 const BUILD_POLL_TIME = 5 * 60 * 1000;
 const BUILD_POLL_INTERVAL = 5 * 1000;
 
+interface JspmCache {
+  lookupCache: Map<string, Promise<ExactPackage>>;
+  versionsCacheMap: Map<string, string[]>;
+  resolveCache: Record<
+    string,
+    {
+      latest: Promise<ExactPackage | null>;
+      majors: Record<string, Promise<ExactPackage | null>>;
+      minors: Record<string, Promise<ExactPackage | null>>;
+      tags: Record<string, Promise<ExactPackage | null>>;
+    }
+  >;
+  cachedErrors: Map<string, Promise<boolean>>;
+  buildRequested: Map<string, Promise<void>>;
+}
+
 export const supportedLayers = ["default", "system"];
 
 export async function pkgToUrl(
@@ -28,8 +44,6 @@ export async function pkgToUrl(
 export function configure(config: any) {
   if (config.cdnUrl)
     cdnUrl = config.cdnUrl;
-  lookupCache = new Map();
-  versionsCacheMap = new Map();
 }
 
 const exactPkgRegEx =
@@ -61,21 +75,19 @@ export function parseUrlPkg(url: string) {
   }
 }
 
-let resolveCache: Record<
-  string,
-  {
-    latest: Promise<ExactPackage | null>;
-    majors: Record<string, Promise<ExactPackage | null>>;
-    minors: Record<string, Promise<ExactPackage | null>>;
-    tags: Record<string, Promise<ExactPackage | null>>;
+function getJspmCache (resolver: Resolver): JspmCache {
+  const jspmCache = resolver.context.jspmCache;
+  if (!resolver.context.jspmCache) {
+    return resolver.context.jspmCache = {
+      lookupCache: new Map(),
+      versionsCacheMap: new Map(),
+      resolveCache: {},
+      cachedErrors: new Map(),
+      buildRequested: new Map(),
+    };
   }
-> = {};
-
-export function clearResolveCache() {
-  resolveCache = {};
+  return jspmCache;
 }
-
-const cachedErrors = new Map();
 
 async function checkBuildOrError(
   resolver: Resolver,
@@ -86,6 +98,7 @@ async function checkBuildOrError(
   if (pcfg) {
     return true;
   }
+  const { cachedErrors } = getJspmCache(resolver);
   // no package.json! Check if there's a build error:
   if (cachedErrors.has(pkgUrl))
     return cachedErrors.get(pkgUrl);
@@ -106,13 +119,13 @@ async function checkBuildOrError(
   return cachedErrorPromise;
 }
 
-const buildRequested = new Map();
-
 async function ensureBuild(resolver: Resolver, pkg: ExactPackage, fetchOpts: any) {
   if (await checkBuildOrError(resolver, await pkgToUrl(pkg, "default"), fetchOpts))
     return;
 
   const fullName = `${pkg.name}@${pkg.version}`;
+
+  const { buildRequested } = getJspmCache(resolver);
 
   // no package.json AND no build error -> post a build request
   // once the build request has been posted, try polling for up to 2 mins
@@ -159,6 +172,8 @@ export async function resolveLatestTarget(
     await ensureBuild(this, pkg, this.fetchOpts);
     return pkg;
   }
+
+  const { resolveCache } = getJspmCache(this);
 
   const cache = (resolveCache[target.registry + ":" + target.name] =
     resolveCache[target.registry + ":" + target.name] || {
@@ -277,8 +292,6 @@ function pkgToLookupUrl(pkg: ExactPackage, edge = false) {
   }`;
 }
 
-let lookupCache = new Map();
-
 async function lookupRange(
   this: Resolver,
   registry: string,
@@ -287,6 +300,7 @@ async function lookupRange(
   unstable: boolean,
   parentUrl?: string
 ): Promise<ExactPackage | null> {
+  const { lookupCache } = getJspmCache(this);
   const url = pkgToLookupUrl({ registry, name, version: range }, unstable);
   if (lookupCache.has(url))
     return lookupCache.get(url);
@@ -296,7 +310,7 @@ async function lookupRange(
       return { registry, name, version: version.trim() };
     } else {
       // not found
-      const versions = await fetchVersions(name);
+      const versions = await fetchVersions.call(this, name);
       const semverRange = new SemverRange(String(range) || "*", unstable);
       const version = semverRange.bestMatch(versions, unstable);
 
@@ -314,9 +328,8 @@ async function lookupRange(
   return lookupPromise;
 }
 
-let versionsCacheMap = new Map<string, string[]>();
-
-export async function fetchVersions(name: string): Promise<string[]> {
+export async function fetchVersions(this: Resolver, name: string): Promise<string[]> {
+  const { versionsCacheMap } = getJspmCache(this);
   if (versionsCacheMap.has(name)) {
     return versionsCacheMap.get(name);
   }

--- a/src/providers/skypack.ts
+++ b/src/providers/skypack.ts
@@ -28,7 +28,7 @@ export async function resolveLatestTarget(
   parentUrl: string
 ): Promise<ExactPackage | null> {
   const { registry, name, range, unstable } = target;
-  const versions = await fetchVersions(name);
+  const versions = await fetchVersions.call(this, name);
   const semverRange = new SemverRange(String(range) || "*", unstable);
   const version = semverRange.bestMatch(versions, unstable);
   if (version) {

--- a/src/providers/unpkg.ts
+++ b/src/providers/unpkg.ts
@@ -29,7 +29,7 @@ export async function resolveLatestTarget(
   parentUrl: string
 ): Promise<ExactPackage | null> {
   const { registry, name, range, unstable } = target;
-  const versions = await fetchVersions(name);
+  const versions = await fetchVersions.call(this, name);
   const semverRange = new SemverRange(String(range) || "*", unstable);
   const version = semverRange.bestMatch(versions, unstable);
   if (version) {

--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -104,6 +104,7 @@ export class Resolver {
   traceCjs: boolean;
   traceTs: boolean;
   traceSystem: boolean;
+  context: Record<string, any>;
   constructor({
     env,
     log,
@@ -132,6 +133,7 @@ export class Resolver {
     this.traceCjs = traceCjs;
     this.traceTs = traceTs;
     this.traceSystem = traceSystem;
+    this.context = {};
   }
 
   addCustomProvider(name: string, provider: Provider) {
@@ -359,8 +361,8 @@ export class Resolver {
     const resolveLatestTarget = getProvider(
       provider,
       this.providers
-    ).resolveLatestTarget.bind(this);
-    const pkg = await resolveLatestTarget(latestTarget, layer, parentUrl);
+    ).resolveLatestTarget;
+    const pkg = await resolveLatestTarget.call(this, latestTarget, layer, parentUrl);
     if (pkg) return pkg;
 
     if (provider === "nodemodules") {


### PR DESCRIPTION
The performance caching work done in https://github.com/jspm/generator/pull/380 created a version cache which wasn't being cleared between generator instantiations - and as a result, `api.jspm.io` isn't getting version updates.

This resolves that to ensure each new generator instance maintains its cache associated with the resolver context and that this cache is not shared between instances.