### PR TITLE
feat: allow customizing fetch with a setFetch export

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "@jspm/generator",
-  "version": "2.3.0",
+  "version": "2.3.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "@jspm/generator",
-      "version": "2.3.0",
+      "version": "2.3.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@babel/core": "^7.24.7",

--- a/src/common/fetch.ts
+++ b/src/common/fetch.ts
@@ -1,0 +1,125 @@
+// @ts-ignore
+import { fetch as fetchImpl, clearCache } from '#fetch';
+
+export interface WrappedResponse {
+  status: number;
+  statusText?: string;
+  text?(): Promise<string>;
+  json?(): Promise<any>;
+  arrayBuffer?(): ArrayBuffer;
+}
+
+export type FetchFn = (
+  url: URL | string,
+  ...args: any[]
+) => Promise<WrappedResponse | globalThis.Response>
+
+export type WrappedFetch = ((
+  url: URL | string,
+  ...args: any[]
+) => Promise<WrappedResponse | globalThis.Response>)  & {
+  arrayBuffer: (url: URL | string, ...args: any[]) => Promise<ArrayBuffer | null>,
+  text: (url: URL | string, ...args: any[]) => Promise<string | null>
+};
+
+let retryCount = 5, poolSize = 100;
+
+export function setRetryCount(count: number) {
+  retryCount = count;
+}
+
+export function setFetchPoolSize(size: number) {
+  poolSize = size;
+}
+
+let _fetch: WrappedFetch = wrappedFetch(fetchImpl);
+
+/**
+ * Allows customizing the fetch implementation used by the generator.
+ */
+export function setFetch(fetch: typeof globalThis.fetch | WrappedFetch) {
+  _fetch = fetch as WrappedFetch;
+}
+
+export { clearCache, _fetch as fetch }
+
+/**
+ * Wraps a fetch request with pooling, and retry logic on exceptions (emfile / network errors).
+ */
+function wrappedFetch(fetch: FetchFn): WrappedFetch {
+  const wrappedFetch = async function (url: URL | string, ...args: any[]) {
+    url = url.toString();
+    let retries = 0;
+    try {
+      await pushFetchPool();
+      while (true) {
+        try {
+          return await fetch(url, ...args);
+        } catch (e) {
+          if (retries++ >= retryCount) throw e;
+        }
+      }
+    } finally {
+      popFetchPool();
+    }
+  };
+  wrappedFetch.arrayBuffer = async function (url, ...args) {
+    url = url.toString();
+    let retries = 0;
+    try {
+      await pushFetchPool();
+      while (true) {
+        try {
+          var res = await fetch(url, ...args);
+        } catch (e) {
+          if (retries++ >= retryCount)
+            throw e;
+          continue;
+        }
+        switch (res.status) {
+          case 200:
+          case 304:
+            break;
+          // not found = null
+          case 404:
+            return null;
+          default:
+            throw new Error(`Invalid status code ${res.status}`);
+        }
+        try {
+          return await res.arrayBuffer();
+        } catch (e) {
+          if (retries++ >= retryCount &&
+              e.code === "ERR_SOCKET_TIMEOUT" ||
+              e.code === "ETIMEOUT" ||
+              e.code === "ECONNRESET" ||
+              e.code === 'FETCH_ERROR') {
+
+          }
+        }
+      }
+    } finally {
+      popFetchPool();
+    }
+  };
+  wrappedFetch.text = async function (url, ...args) {
+    const arrayBuffer = await this.arrayBuffer(url, ...args);
+    if (!arrayBuffer)
+        return null;
+    return new TextDecoder().decode(arrayBuffer);
+  };
+  return wrappedFetch;
+}
+
+// restrict in-flight fetches to a pool of 100
+let p = [];
+let c = 0;
+function pushFetchPool () {
+  if (++c > poolSize)
+    return new Promise(r => p.push(r));
+}
+function popFetchPool () {
+  c--;
+  if (p.length)
+    p.shift()();
+}

--- a/src/common/fetch.ts
+++ b/src/common/fetch.ts
@@ -2,6 +2,9 @@
 import { fetch as fetchImpl, clearCache } from '#fetch';
 
 export interface WrappedResponse {
+  url: string;
+  headers: Headers;
+  ok: boolean;
   status: number;
   statusText?: string;
   text?(): Promise<string>;

--- a/src/common/wrapper.ts
+++ b/src/common/wrapper.ts
@@ -1,5 +1,4 @@
-//@ts-ignore
-import { fetch } from "#fetch";
+import { fetch } from "../common/fetch.js";
 import { parse, init } from "es-module-lexer";
 
 export async function getMaybeWrapperUrl(moduleUrl, fetchOpts) {

--- a/src/generator.ts
+++ b/src/generator.ts
@@ -29,7 +29,7 @@ import {
 } from "./install/package.js";
 import TraceMap from "./trace/tracemap.js";
 // @ts-ignore
-import { clearCache as clearFetchCache, fetch as _fetch } from "#fetch";
+import { clearCache as clearFetchCache, fetch as _fetch, setFetch } from "./common/fetch.js";
 import { IImportMap, ImportMap } from "@jspm/import-map";
 import process from "process";
 import { SemverRange } from "sver";
@@ -46,8 +46,12 @@ import { Resolver } from "./trace/resolver.js";
 import { getMaybeWrapperUrl } from "./common/wrapper.js";
 import { setRetryCount } from "./common/fetch-common.js";
 
-// Utility exports for users:
-export { analyzeHtml };
+export {
+  // utility export
+  analyzeHtml,
+  // hook export
+  setFetch
+};
 
 // Type exports for users:
 export { Provider };
@@ -159,7 +163,7 @@ export interface GeneratorOptions {
   cache?: "offline" | boolean;
 
   /**
-   * User-provided fetch options for fetching modules, check https://github.com/npm/make-fetch-happen#extra-options
+   * User-provided fetch options for fetching modules, eg check https://github.com/npm/make-fetch-happen#extra-options for Node.js fetch
    */
   fetchOptions?: Record<string, any>;
 

--- a/src/providers/deno.ts
+++ b/src/providers/deno.ts
@@ -6,7 +6,7 @@ import {
 import { Resolver } from "../trace/resolver.js";
 import { SemverRange } from "sver";
 // @ts-ignore
-import { fetch } from "#fetch";
+import { fetch } from "../common/fetch.js";
 import { Install } from "../generator.js";
 
 const cdnUrl = "https://deno.land/x/";

--- a/src/providers/esmsh.ts
+++ b/src/providers/esmsh.ts
@@ -1,7 +1,7 @@
 import { ExactPackage, LatestPackageTarget, PackageConfig } from "../install/package.js";
 import { Resolver } from "../trace/resolver.js";
 // @ts-ignore
-import { fetch } from "#fetch";
+import { fetch } from "../common/fetch.js";
 import { JspmError } from "../common/err.js";
 import { fetchVersions } from "./jspm.js";
 // @ts-ignore

--- a/src/providers/jspm.ts
+++ b/src/providers/jspm.ts
@@ -7,7 +7,7 @@ import { Resolver } from "../trace/resolver.js";
 // @ts-ignore
 import { SemverRange } from "sver";
 // @ts-ignore
-import { fetch } from "#fetch";
+import { fetch } from "../common/fetch.js";
 
 let cdnUrl = "https://ga.jspm.io/";
 const systemCdnUrl = "https://ga.system.jspm.io/";

--- a/src/providers/nodemodules.ts
+++ b/src/providers/nodemodules.ts
@@ -3,7 +3,7 @@ import { ExactPackage } from "../install/package.js";
 import { Resolver } from "../trace/resolver.js";
 import { Provider } from "./index.js";
 // @ts-ignore
-import { fetch } from "#fetch";
+import { fetch } from "../common/fetch.js";
 import { JspmError } from "../common/err.js";
 import { importedFrom } from "../common/url.js";
 import { PackageConfig } from "../install/package.js";

--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -8,7 +8,7 @@ import {
 import { JspmError } from "../common/err.js";
 import { Log } from "../common/log.js";
 // @ts-ignore
-import { fetch } from "#fetch";
+import { fetch } from "../common/fetch.js";
 import { importedFrom } from "../common/url.js";
 // @ts-ignore
 import { parse } from "es-module-lexer/js";

--- a/test/npm-compatibility/install-pkg.test.js
+++ b/test/npm-compatibility/install-pkg.test.js
@@ -1,4 +1,4 @@
-import { fetch } from "#fetch";
+import { fetch } from "../../lib/common/fetch.js";
 import { Generator } from "@jspm/generator";
 import assert from "assert";
 

--- a/test/npm-compatibility/install.test.js
+++ b/test/npm-compatibility/install.test.js
@@ -1,4 +1,4 @@
-import { fetch } from "#fetch";
+import { fetch } from "../../lib/common/fetch.js";
 import { Generator } from "@jspm/generator";
 import assert from "assert";
 

--- a/test/npm-compatibility/update-pkg.test.js
+++ b/test/npm-compatibility/update-pkg.test.js
@@ -1,4 +1,4 @@
-import { fetch } from "#fetch";
+import { fetch } from "../../lib/common/fetch.js";
 import { Generator } from "@jspm/generator";
 import assert from "assert";
 

--- a/test/npm-compatibility/update.test.js
+++ b/test/npm-compatibility/update.test.js
@@ -1,4 +1,4 @@
-import { fetch } from "#fetch";
+import { fetch } from "../../lib/common/fetch.js";
 import { Generator } from "@jspm/generator";
 import assert from "assert";
 

--- a/test/perf/perf.test.js
+++ b/test/perf/perf.test.js
@@ -1,6 +1,6 @@
 import { Generator } from "@jspm/generator";
 import assert from "assert";
-import { fetch } from '#fetch';
+import { fetch } from '../../lib/common/fetch.js';
 
 const largeInstallSet = await (await fetch(new URL('./large-install-set.json', import.meta.url), {})).json();
 


### PR DESCRIPTION
This allows customizing the fetch function with a `setFetch` export from the generator:

```js
import { setFetch } from '@jspm/generator';
setFetch(myCustomFetchImplementation);
```