### PR TITLE
fix: dont trace ts type imports

### DIFF
--- a/src/trace/ts.ts
+++ b/src/trace/ts.ts
@@ -85,13 +85,15 @@ export async function createTsAnalysis(
           return {
             visitor: {
               ExportAllDeclaration(path) {
-                imports.add(path.node.source.value);
+                if (path.node.exportKind !== 'type')
+                  imports.add(path.node.source.value);
               },
               ExportNamedDeclaration(path) {
                 if (path.node.source) imports.add(path.node.source.value);
               },
               ImportDeclaration(path) {
-                imports.add(path.node.source.value);
+                if (path.node.exportKind !== 'type')
+                  imports.add(path.node.source.value);
               },
               Import(path) {
                 dynamicImports.add(

--- a/test/resolve/tspkg/main.ts
+++ b/test/resolve/tspkg/main.ts
@@ -1,2 +1,3 @@
+import type { t } from './types.ts';
 import "./dep.ts";
-export var p: number = 5;
+export var p: t = 5;

--- a/test/resolve/tspkg/types.ts
+++ b/test/resolve/tspkg/types.ts
@@ -1,0 +1,4 @@
+// should not be traced!
+import 'jquery';
+
+export type t = number;


### PR DESCRIPTION
This disabled the tracing of `import type` statements entirely better supporting TS workflows.