### PR TITLE
fix: regular analysis of System.register may get stuck (#393)

### DIFF
--- a/src/trace/analysis.ts
+++ b/src/trace/analysis.ts
@@ -1,3 +1,4 @@
+import babel from '@babel/core'
 import { JspmError } from "../common/err.js";
 import { getIntegrity } from "../common/integrity.js";
 
@@ -32,7 +33,8 @@ export async function createEsmAnalysis(
   source: string,
   url: string
 ): Promise<Analysis> { // Change the return type to Promise<Analysis>
-  if (!imports.length && registerRegEx.test(source))
+  const coolSource = babel.transformSync(source, {comments: false}).code;
+  if (!imports.length && registerRegEx.test(coolSource))
     return createSystemAnalysis(source, imports, url);
   const deps: string[] = [];
   const dynamicDeps: string[] = [];
@@ -75,7 +77,8 @@ export async function createSystemAnalysis(
   imports: string[],
   url: string
 ): Promise<Analysis> {
-  const [, , , rawDeps, , , contextId] = source.match(registerRegEx) || [];
+  const coolSource = babel.transformSync(source, {comments: false}).code;
+  const [, , , rawDeps, , , contextId] = coolSource.match(registerRegEx) || [];
   if (!rawDeps) return createEsmAnalysis(imports, source, url);
   const deps = JSON.parse(rawDeps.replace(/'/g, '"'));
   const dynamicDeps: string[] = [];


### PR DESCRIPTION
When the regular encounters source code containing comments, it may get stuck. Remove the code comments before matching
https://github.com/jspm/generator/blob/dfce0abf2dc6b6fbe5ff39484ea5db9d4b05b2b1/src/trace/analysis.ts#L71

case：
https://github.com/faisalman/ua-parser-js/blob/master/src/main/ua-parser.js