### PR TITLE
fix: update operation on packages without exports

### DIFF
--- a/src/trace/resolver.ts
+++ b/src/trace/resolver.ts
@@ -634,20 +634,6 @@ export class Resolver {
         return bestMatch;
       }
     } else {
-      if (subpath !== ".") {
-        try {
-          if (
-            (await this.finalizeResolve(
-              new URL(subpath, new URL(pkgUrl)).href,
-              false,
-              false,
-              pkgUrl
-            )) === resolvedUrl
-          )
-            return ".";
-        } catch {}
-        return null;
-      }
       try {
         if (
           typeof pcfg.main === "string" &&
@@ -718,10 +704,19 @@ export class Resolver {
           )) === resolvedUrl
         )
           return ".";
-        return null;
+      } catch {}
+      try {
+        if (
+          (await this.finalizeResolve(
+            new URL(subpath, new URL(pkgUrl)).href,
+            false,
+            false,
+            pkgUrl
+          )) === resolvedUrl
+        )
+          return subpath;
       } catch {}
     }
-    return null;
   }
 
   async resolveEmpty(

--- a/test/api/update.test.js
+++ b/test/api/update.test.js
@@ -1,76 +1,76 @@
 import { Generator, lookup } from "@jspm/generator";
 import assert from "assert";
 
-// {
-//   const generator = new Generator({
-//     inputMap: {
-//       imports: {
-//         react: "https://ga.jspm.io/npm:react@17.0.1/dev.index.js",
-//       },
-//       scopes: {
-//         "https://ga.jspm.io/": {
-//           "object-assign":
-//             "https://ga.jspm.io/npm:object-assign@4.1.0/index.js",
-//         },
-//       },
-//     },
-//     mapUrl: import.meta.url,
-//     defaultProvider: "jspm.io",
-//     env: ["production", "browser"],
-//   });
+{
+  const generator = new Generator({
+    inputMap: {
+      imports: {
+        react: "https://ga.jspm.io/npm:react@17.0.1/dev.index.js",
+      },
+      scopes: {
+        "https://ga.jspm.io/": {
+          "object-assign":
+            "https://ga.jspm.io/npm:object-assign@4.1.0/index.js",
+        },
+      },
+    },
+    mapUrl: import.meta.url,
+    defaultProvider: "jspm.io",
+    env: ["production", "browser"],
+  });
 
-//   await generator.update("react");
-//   const json = generator.getMap();
+  await generator.update("react");
+  const json = generator.getMap();
 
-//   assert.strictEqual(
-//     json.imports.react,
-//     "https://ga.jspm.io/npm:react@17.0.2/index.js"
-//   );
-//   assert.strictEqual(
-//     json.scopes["https://ga.jspm.io/"]["object-assign"],
-//     "https://ga.jspm.io/npm:object-assign@4.1.1/index.js"
-//   );
-//   assert.strictEqual(Object.keys(json.imports).length, 1);
-//   assert.strictEqual(Object.keys(json.scopes["https://ga.jspm.io/"]).length, 1);
-// }
+  assert.strictEqual(
+    json.imports.react,
+    "https://ga.jspm.io/npm:react@17.0.2/index.js"
+  );
+  assert.strictEqual(
+    json.scopes["https://ga.jspm.io/"]["object-assign"],
+    "https://ga.jspm.io/npm:object-assign@4.1.1/index.js"
+  );
+  assert.strictEqual(Object.keys(json.imports).length, 1);
+  assert.strictEqual(Object.keys(json.scopes["https://ga.jspm.io/"]).length, 1);
+}
 
-// {
-//   const generator = new Generator({
-//     inputMap: {
-//       imports: {
-//         lit: "https://ga.jspm.io/npm:lit@2.2.4/index.js",
-//         "lit/directive.js": "https://ga.jspm.io/npm:lit@2.2.4/directive.js",
-//       },
-//       scopes: {
-//         "https://ga.jspm.io/": {
-//           "@lit/reactive-element":
-//             "https://ga.jspm.io/npm:@lit/reactive-element@1.3.4/reactive-element.js",
-//           "lit-element/lit-element.js":
-//             "https://ga.jspm.io/npm:lit-element@3.2.2/lit-element.js",
-//           "lit-html": "https://ga.jspm.io/npm:lit-html@2.2.7/lit-html.js",
-//           "lit-html/directive.js":
-//             "https://ga.jspm.io/npm:lit-html@2.2.7/directive.js",
-//         },
-//       },
-//     },
-//     mapUrl: import.meta.url,
-//     defaultProvider: "jspm.io",
-//     env: ["production", "browser"],
-//   });
+{
+  const generator = new Generator({
+    inputMap: {
+      imports: {
+        lit: "https://ga.jspm.io/npm:lit@2.2.4/index.js",
+        "lit/directive.js": "https://ga.jspm.io/npm:lit@2.2.4/directive.js",
+      },
+      scopes: {
+        "https://ga.jspm.io/": {
+          "@lit/reactive-element":
+            "https://ga.jspm.io/npm:@lit/reactive-element@1.3.4/reactive-element.js",
+          "lit-element/lit-element.js":
+            "https://ga.jspm.io/npm:lit-element@3.2.2/lit-element.js",
+          "lit-html": "https://ga.jspm.io/npm:lit-html@2.2.7/lit-html.js",
+          "lit-html/directive.js":
+            "https://ga.jspm.io/npm:lit-html@2.2.7/directive.js",
+        },
+      },
+    },
+    mapUrl: import.meta.url,
+    defaultProvider: "jspm.io",
+    env: ["production", "browser"],
+  });
 
-//   await generator.update("lit");
-//   const json = generator.getMap();
-//   const expectedVersion = (await lookup("lit@2")).resolved.version;
+  await generator.update("lit");
+  const json = generator.getMap();
+  const expectedVersion = (await lookup("lit@2")).resolved.version;
 
-//   assert.strictEqual(
-//     json.imports.lit,
-//     `https://ga.jspm.io/npm:lit@${expectedVersion}/index.js`
-//   );
-//   assert.strictEqual(
-//     json.imports["lit/directive.js"],
-//     `https://ga.jspm.io/npm:lit@${expectedVersion}/directive.js`
-//   );
-// }
+  assert.strictEqual(
+    json.imports.lit,
+    `https://ga.jspm.io/npm:lit@${expectedVersion}/index.js`
+  );
+  assert.strictEqual(
+    json.imports["lit/directive.js"],
+    `https://ga.jspm.io/npm:lit@${expectedVersion}/directive.js`
+  );
+}
 
 {
   const generator = new Generator({ defaultProvider: 'jsdelivr' });

--- a/test/api/update.test.js
+++ b/test/api/update.test.js
@@ -1,73 +1,96 @@
 import { Generator, lookup } from "@jspm/generator";
 import assert from "assert";
 
+// {
+//   const generator = new Generator({
+//     inputMap: {
+//       imports: {
+//         react: "https://ga.jspm.io/npm:react@17.0.1/dev.index.js",
+//       },
+//       scopes: {
+//         "https://ga.jspm.io/": {
+//           "object-assign":
+//             "https://ga.jspm.io/npm:object-assign@4.1.0/index.js",
+//         },
+//       },
+//     },
+//     mapUrl: import.meta.url,
+//     defaultProvider: "jspm.io",
+//     env: ["production", "browser"],
+//   });
+
+//   await generator.update("react");
+//   const json = generator.getMap();
+
+//   assert.strictEqual(
+//     json.imports.react,
+//     "https://ga.jspm.io/npm:react@17.0.2/index.js"
+//   );
+//   assert.strictEqual(
+//     json.scopes["https://ga.jspm.io/"]["object-assign"],
+//     "https://ga.jspm.io/npm:object-assign@4.1.1/index.js"
+//   );
+//   assert.strictEqual(Object.keys(json.imports).length, 1);
+//   assert.strictEqual(Object.keys(json.scopes["https://ga.jspm.io/"]).length, 1);
+// }
+
+// {
+//   const generator = new Generator({
+//     inputMap: {
+//       imports: {
+//         lit: "https://ga.jspm.io/npm:lit@2.2.4/index.js",
+//         "lit/directive.js": "https://ga.jspm.io/npm:lit@2.2.4/directive.js",
+//       },
+//       scopes: {
+//         "https://ga.jspm.io/": {
+//           "@lit/reactive-element":
+//             "https://ga.jspm.io/npm:@lit/reactive-element@1.3.4/reactive-element.js",
+//           "lit-element/lit-element.js":
+//             "https://ga.jspm.io/npm:lit-element@3.2.2/lit-element.js",
+//           "lit-html": "https://ga.jspm.io/npm:lit-html@2.2.7/lit-html.js",
+//           "lit-html/directive.js":
+//             "https://ga.jspm.io/npm:lit-html@2.2.7/directive.js",
+//         },
+//       },
+//     },
+//     mapUrl: import.meta.url,
+//     defaultProvider: "jspm.io",
+//     env: ["production", "browser"],
+//   });
+
+//   await generator.update("lit");
+//   const json = generator.getMap();
+//   const expectedVersion = (await lookup("lit@2")).resolved.version;
+
+//   assert.strictEqual(
+//     json.imports.lit,
+//     `https://ga.jspm.io/npm:lit@${expectedVersion}/index.js`
+//   );
+//   assert.strictEqual(
+//     json.imports["lit/directive.js"],
+//     `https://ga.jspm.io/npm:lit@${expectedVersion}/directive.js`
+//   );
+// }
+
 {
-  const generator = new Generator({
-    inputMap: {
-      imports: {
-        react: "https://ga.jspm.io/npm:react@17.0.1/dev.index.js",
-      },
-      scopes: {
-        "https://ga.jspm.io/": {
-          "object-assign":
-            "https://ga.jspm.io/npm:object-assign@4.1.0/index.js",
-        },
-      },
-    },
-    mapUrl: import.meta.url,
-    defaultProvider: "jspm.io",
-    env: ["production", "browser"],
+  const generator = new Generator({ defaultProvider: 'jsdelivr' });
+  await generator.addMappings({
+    "imports": {
+      "lodash": "https://cdn.jsdelivr.net/npm/lodash@4.17.20/lodash.js",
+      "lodash/filter.js": "https://cdn.jsdelivr.net/npm/lodash@4.17.20/filter.js"
+    }  
   });
 
-  await generator.update("react");
+  await generator.update();
   const json = generator.getMap();
+  const expectedVersion = (await lookup("lodash@4")).resolved.version;
 
   assert.strictEqual(
-    json.imports.react,
-    "https://ga.jspm.io/npm:react@17.0.2/index.js"
+    json.imports.lodash,
+    `https://cdn.jsdelivr.net/npm/lodash@${expectedVersion}/lodash.js`
   );
   assert.strictEqual(
-    json.scopes["https://ga.jspm.io/"]["object-assign"],
-    "https://ga.jspm.io/npm:object-assign@4.1.1/index.js"
-  );
-  assert.strictEqual(Object.keys(json.imports).length, 1);
-  assert.strictEqual(Object.keys(json.scopes["https://ga.jspm.io/"]).length, 1);
-}
-
-{
-  const generator = new Generator({
-    inputMap: {
-      imports: {
-        lit: "https://ga.jspm.io/npm:lit@2.2.4/index.js",
-        "lit/directive.js": "https://ga.jspm.io/npm:lit@2.2.4/directive.js",
-      },
-      scopes: {
-        "https://ga.jspm.io/": {
-          "@lit/reactive-element":
-            "https://ga.jspm.io/npm:@lit/reactive-element@1.3.4/reactive-element.js",
-          "lit-element/lit-element.js":
-            "https://ga.jspm.io/npm:lit-element@3.2.2/lit-element.js",
-          "lit-html": "https://ga.jspm.io/npm:lit-html@2.2.7/lit-html.js",
-          "lit-html/directive.js":
-            "https://ga.jspm.io/npm:lit-html@2.2.7/directive.js",
-        },
-      },
-    },
-    mapUrl: import.meta.url,
-    defaultProvider: "jspm.io",
-    env: ["production", "browser"],
-  });
-
-  await generator.update("lit");
-  const json = generator.getMap();
-  const expectedVersion = (await lookup("lit@2")).resolved.version;
-
-  assert.strictEqual(
-    json.imports.lit,
-    `https://ga.jspm.io/npm:lit@${expectedVersion}/index.js`
-  );
-  assert.strictEqual(
-    json.imports["lit/directive.js"],
-    `https://ga.jspm.io/npm:lit@${expectedVersion}/directive.js`
+    json.imports['lodash/filter.js'],
+    `https://cdn.jsdelivr.net/npm/lodash@${expectedVersion}/filter.js`
   );
 }

--- a/test/providers/esmsh-root.test.js
+++ b/test/providers/esmsh-root.test.js
@@ -2,31 +2,24 @@ import { Generator } from "@jspm/generator";
 import assert from "assert";
 
 const inputMap = {
-  imports: {
-    "react-intl": "https://esm.sh/*react-intl@6.4.4/lib/index.js",
+  "imports": {
+    "react-intl": "https://esm.sh/*react-intl@6.4.4/lib/index.js"
   },
-  scopes: {
+  "scopes": {
     "https://esm.sh/": {
-      "@formatjs/ecma402-abstract":
-        "https://esm.sh/*@formatjs/ecma402-abstract@1.17.0/lib/index.js",
-      "@formatjs/fast-memoize":
-        "https://esm.sh/*@formatjs/fast-memoize@2.2.0/lib/index.js",
-      "@formatjs/icu-messageformat-parser":
-        "https://esm.sh/*@formatjs/icu-messageformat-parser@2.6.0/lib/index.js",
-      "@formatjs/icu-skeleton-parser":
-        "https://esm.sh/*@formatjs/icu-skeleton-parser@1.6.0/lib/index.js",
+      "@formatjs/ecma402-abstract": "https://esm.sh/*@formatjs/ecma402-abstract@1.17.0/lib/index.js",
+      "@formatjs/fast-memoize": "https://esm.sh/*@formatjs/fast-memoize@2.2.0/lib/index.js",
+      "@formatjs/icu-messageformat-parser": "https://esm.sh/*@formatjs/icu-messageformat-parser@2.6.0/lib/index.js",
+      "@formatjs/icu-skeleton-parser": "https://esm.sh/*@formatjs/icu-skeleton-parser@1.6.0/lib/index.js",
       "@formatjs/intl": "https://esm.sh/*@formatjs/intl@2.9.0/lib/index.js",
-      "@formatjs/intl-localematcher":
-        "https://esm.sh/*@formatjs/intl-localematcher@0.4.0/lib/index.js",
-      "hoist-non-react-statics":
-        "https://esm.sh/*hoist-non-react-statics@3.3.2/dist/hoist-non-react-statics.cjs.js/index.js",
-      "intl-messageformat":
-        "https://esm.sh/*intl-messageformat@10.5.0/lib/index.js",
-      react: "https://esm.sh/*react@18.2.0",
+      "@formatjs/intl-localematcher": "https://esm.sh/*@formatjs/intl-localematcher@0.4.0/lib/index.js",
+      "hoist-non-react-statics": "https://esm.sh/*hoist-non-react-statics@3.3.2/dist/hoist-non-react-statics.cjs.js",
+      "intl-messageformat": "https://esm.sh/*intl-messageformat@10.5.0/lib/index.js",
+      "react": "https://esm.sh/*react@18.3.1/index.js",
       "react-is": "https://esm.sh/*react-is@16.13.1/index.js",
-      tslib: "https://esm.sh/*tslib@2.6.1",
-    },
-  },
+      "tslib": "https://esm.sh/*tslib@2.8.1/tslib.es6.mjs"
+    }
+  }
 };
 
 const generator = new Generator({


### PR DESCRIPTION
This fixes the extract lock and deps for packages without exports better handling the package deconstruction in order to support updating multiple top-level imports mappings.

Resolves #409.